### PR TITLE
Compute nightly workflow paramters

### DIFF
--- a/.github/workflows/get-run-info.yaml
+++ b/.github/workflows/get-run-info.yaml
@@ -6,13 +6,14 @@ on:
       repos:
         type: string
     outputs:
-      shas:
-        description: "A JSON object which includes the current SHA for the given branch in each repository."
-        value: ${{ jobs.run.outputs.shas }}
+      obj:
+        description: "A JSON object which includes the relevant information for a particular workflow run."
+        value: ${{ jobs.run.outputs.obj }}
 
 # The output object looks like this:
 # {
 #   "branch": "branch-22.10",
+#   "date": "2022-09-01",
 #   "shas": {
 #     "rmm": "8a3a552e07fa8254c54804addcab103aea89f985",
 #     "cudf": "dfd3d89392fa4710752e3067b16fa9a2edb28174"
@@ -23,12 +24,12 @@ jobs:
   run:
     runs-on: ubuntu-latest
     outputs:
-      shas: ${{ steps.get-shas.outputs.shas }}
+      obj: ${{ steps.get-obj.outputs.obj }}
     env:
       GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
     steps:
-      - name: Get SHAs
-        id: get-shas
+      - name: Get Run Info
+        id: get-obj
         env:
           INPUTS_CONTEXT: ${{ toJson(inputs) }}
         run: |
@@ -40,6 +41,13 @@ jobs:
             export SHA=$(gh api -q '.commit.sha' "repos/${REPO}/branches/${{ inputs.branch }}")
             SHAs=$(jq -nc '(env.SHAs|fromjson) + {(env.JUST_REPO): env.SHA}')
           done
-          OBJ=$(jq -nc '{"branch": "${{ inputs.branch }}", "shas": (env.SHAs|fromjson)}')
+
+          OBJ=$(
+            jq -nc '{
+              "branch": "${{ inputs.branch }}",
+              "shas": (env.SHAs|fromjson),
+              "date": now | strftime("%F"),
+            }'
+          )
           echo "${OBJ}"
-          echo "::set-output name=shas::${OBJ}"
+          echo "::set-output name=obj::${OBJ}"

--- a/.github/workflows/get-shas.yaml
+++ b/.github/workflows/get-shas.yaml
@@ -1,0 +1,45 @@
+on:
+  workflow_call:
+    inputs:
+      branch:
+        type: string
+      repos:
+        type: string
+    outputs:
+      shas:
+        description: "A JSON object which includes the current SHA for the given branch in each repository."
+        value: ${{ jobs.run.outputs.shas }}
+
+# The output object looks like this:
+# {
+#   "branch": "branch-22.10",
+#   "shas": {
+#     "rmm": "8a3a552e07fa8254c54804addcab103aea89f985",
+#     "cudf": "dfd3d89392fa4710752e3067b16fa9a2edb28174"
+#   }
+# }
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    outputs:
+      shas: ${{ steps.get-shas.outputs.shas }}
+    env:
+      GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+    steps:
+      - name: Get SHAs
+        id: get-shas
+        env:
+          INPUTS_CONTEXT: ${{ toJson(inputs) }}
+        run: |
+          export REPOS=$(echo "${{ inputs.repos }}" | jq -Rc 'split(" ")')
+
+          export SHAs='{}'
+          for REPO in $(jq -nr '(env.REPOS|fromjson) | .[]'); do
+            export JUST_REPO=${REPO##*/} # removes GH organization
+            export SHA=$(gh api -q '.commit.sha' "repos/${REPO}/branches/${{ inputs.branch }}")
+            SHAs=$(jq -nc '(env.SHAs|fromjson) + {(env.JUST_REPO): env.SHA}')
+          done
+          OBJ=$(jq -nc '{"branch": "${{ inputs.branch }}", "shas": (env.SHAs|fromjson)}')
+          echo "${OBJ}"
+          echo "::set-output name=shas::${OBJ}"

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -22,9 +22,17 @@ jobs:
       repos: >-
         rapidsai/rmm
         rapidsai/cudf
-  rmm:
+  rmm-build:
     needs: get-run-info
-    uses: rapidsai/rmm/.github/workflows/branch.yaml@update-nightly-workflow
+    uses: rapidsai/rmm/.github/workflows/build.yaml@update-nightly-workflow
+    secrets: inherit
+    with:
+      branch: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+      date: ${{ fromJSON(needs.get-run-info.outputs.obj).date }}
+      sha: ${{ fromJSON(needs.get-run-info.outputs.obj).shas.rmm }}
+  rmm-tests:
+    needs: rmm-build
+    uses: rapidsai/rmm/.github/workflows/test.yaml@update-nightly-workflow
     secrets: inherit
     with:
       branch: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -7,7 +7,7 @@ on:
   #   - cron: ''
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: nightly-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -6,6 +6,9 @@ on:
   # schedule:
   #   - cron: ''
 
+# the static `nightly` string is needed to differentiate
+# this concurrency config from similar configs that exist
+# in called workflows, which causes problems
 concurrency:
   group: nightly-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -11,8 +11,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  get-shas:
+    uses: ./.github/workflows/get-shas.yaml
+    secrets: inherit
+    with:
+      branch: branch-22.10
+      repos: >-
+        rapidsai/rmm
+        rapidsai/cudf
   rmm:
+    needs: [get-shas]
     uses: rapidsai/rmm/.github/workflows/nightly-workflow.yaml@branch-22.10
     secrets: inherit
     with:
-      REF: branch-22.10
+      branch: ${{ fromJSON(needs.get-shas.outputs.shas).branch }}
+      sha: ${{ fromJSON(needs.get-shas.outputs.shas).shas.rmm }}

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -11,8 +11,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  get-shas:
-    uses: ./.github/workflows/get-shas.yaml
+  get-run-info:
+    uses: ./.github/workflows/get-run-info.yaml
     secrets: inherit
     with:
       branch: branch-22.10
@@ -20,9 +20,10 @@ jobs:
         rapidsai/rmm
         rapidsai/cudf
   rmm:
-    needs: [get-shas]
+    needs: get-run-info
     uses: rapidsai/rmm/.github/workflows/branch-workflow.yaml@update-nightly-workflow
     secrets: inherit
     with:
-      branch: ${{ fromJSON(needs.get-shas.outputs.shas).branch }}
-      sha: ${{ fromJSON(needs.get-shas.outputs.shas).shas.rmm }}
+      branch: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+      date: ${{ fromJSON(needs.get-run-info.outputs.obj).date }}
+      sha: ${{ fromJSON(needs.get-run-info.outputs.obj).shas.rmm }}

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -21,7 +21,7 @@ jobs:
         rapidsai/cudf
   rmm:
     needs: get-run-info
-    uses: rapidsai/rmm/.github/workflows/branch-workflow.yaml@update-nightly-workflow
+    uses: rapidsai/rmm/.github/workflows/branch.yaml@update-nightly-workflow
     secrets: inherit
     with:
       branch: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -31,7 +31,7 @@ jobs:
       date: ${{ fromJSON(needs.get-run-info.outputs.obj).date }}
       sha: ${{ fromJSON(needs.get-run-info.outputs.obj).shas.rmm }}
   rmm-tests:
-    needs: rmm-build
+    needs: [get-run-info, rmm-build]
     uses: rapidsai/rmm/.github/workflows/test.yaml@update-nightly-workflow
     secrets: inherit
     with:

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -21,7 +21,7 @@ jobs:
         rapidsai/cudf
   rmm:
     needs: [get-shas]
-    uses: rapidsai/rmm/.github/workflows/nightly-workflow.yaml@branch-22.10
+    uses: rapidsai/rmm/.github/workflows/branch-workflow.yaml@update-nightly-workflow
     secrets: inherit
     with:
       branch: ${{ fromJSON(needs.get-shas.outputs.shas).branch }}

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -24,7 +24,7 @@ jobs:
         rapidsai/cudf
   rmm-build:
     needs: get-run-info
-    uses: rapidsai/rmm/.github/workflows/build.yaml@update-nightly-workflow
+    uses: rapidsai/rmm/.github/workflows/build.yaml@branch-22.10
     secrets: inherit
     with:
       branch: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
@@ -32,7 +32,7 @@ jobs:
       sha: ${{ fromJSON(needs.get-run-info.outputs.obj).shas.rmm }}
   rmm-tests:
     needs: [get-run-info, rmm-build]
-    uses: rapidsai/rmm/.github/workflows/test.yaml@update-nightly-workflow
+    uses: rapidsai/rmm/.github/workflows/test.yaml@branch-22.10
     secrets: inherit
     with:
       branch: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}


### PR DESCRIPTION
This PR adds a new job, `get-run-info`, which is responsible for computing the `date` and `sha`s that will be used as inputs for the remaining jobs in the nightly workflow.

These values are computed to ensure that the same code is built and tested throughout the workflow run.