### PR TITLE
Add `raft` and `cuml` to `nightly-pipeline.yaml`

### DIFF
--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -19,8 +19,10 @@ jobs:
     with:
       branch: branch-23.02
       repos: >-
-        rapidsai/rmm
         rapidsai/cudf
+        rapidsai/cuml
+        rapidsai/raft
+        rapidsai/rmm
   rmm-build:
     needs: get-run-info
     uses: rapidsai/rmm/.github/workflows/build.yaml@branch-23.02
@@ -53,3 +55,35 @@ jobs:
       branch: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
       date: ${{ fromJSON(needs.get-run-info.outputs.obj).date }}
       sha: ${{ fromJSON(needs.get-run-info.outputs.obj).shas.cudf }}
+  raft-build:
+    needs: [get-run-info]
+    uses: rapidsai/raft/.github/workflows/build.yaml@branch-23.02
+    secrets: inherit
+    with:
+      branch: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+      date: ${{ fromJSON(needs.get-run-info.outputs.obj).date }}
+      sha: ${{ fromJSON(needs.get-run-info.outputs.obj).shas.raft }}
+  raft-tests:
+    needs: [get-run-info, raft-build]
+    uses: rapidsai/raft/.github/workflows/test.yaml@branch-23.02
+    secrets: inherit
+    with:
+      branch: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+      date: ${{ fromJSON(needs.get-run-info.outputs.obj).date }}
+      sha: ${{ fromJSON(needs.get-run-info.outputs.obj).shas.raft }}
+  cuml-build:
+    needs: [get-run-info, cudf-build]
+    uses: rapidsai/cuml/.github/workflows/build.yaml@branch-23.02
+    secrets: inherit
+    with:
+      branch: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+      date: ${{ fromJSON(needs.get-run-info.outputs.obj).date }}
+      sha: ${{ fromJSON(needs.get-run-info.outputs.obj).shas.cuml }}
+  cuml-tests:
+    needs: [get-run-info, cuml-build]
+    uses: rapidsai/cuml/.github/workflows/test.yaml@branch-23.02
+    secrets: inherit
+    with:
+      branch: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+      date: ${{ fromJSON(needs.get-run-info.outputs.obj).date }}
+      sha: ${{ fromJSON(needs.get-run-info.outputs.obj).shas.cuml }}


### PR DESCRIPTION
This PR adds `raft` and `cuml` to the `nightly-pipeline.yaml` workflow.