### PR TITLE
Update `nightly-pipeline.yaml`

### DIFF
--- a/.github/workflows/get-run-info-v2.yaml
+++ b/.github/workflows/get-run-info-v2.yaml
@@ -1,0 +1,73 @@
+# once the `pip-wheels-pipeline.yaml` is removed, this file
+# can be renamed to just `get-run-info.yaml`.
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        type: string
+      repos:
+        type: string
+    outputs:
+      obj:
+        description: "A JSON object which includes the relevant information for a particular workflow run."
+        value: ${{ jobs.run.outputs.obj }}
+
+# The output object looks like this:
+# {
+#   "branch": "branch-22.10",
+#   "payloads": {
+#     "rmm": {
+#        "branch": "branch-22.10",
+#        "date": "2022-09-01",
+#        "sha": "8a3a552e07fa8254c54804addcab103aea89f985"
+#      },
+#     "cudf": {
+#        "branch": "branch-22.10",
+#        "date": "2022-09-01",
+#        "sha": "dfd3d89392fa4710752e3067b16fa9a2edb28174"
+#      }
+#   }
+# }
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    outputs:
+      obj: ${{ steps.get-obj.outputs.obj }}
+    env:
+      GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+    steps:
+      - name: Get Run Info
+        id: get-obj
+        env:
+          INPUTS_CONTEXT: ${{ toJson(inputs) }}
+        run: |
+          export DATE=$(date +%F)
+          export BRANCH=${{ inputs.branch }}
+          export REPOS=$(echo "${{ inputs.repos }}" | jq -Rc 'split(" ")')
+
+          export PAYLOADS='{}'
+          for REPO in $(jq -nr '(env.REPOS|fromjson) | .[]'); do
+            export JUST_REPO=${REPO##*/} # removes GH organization
+            export SHA=$(gh api -q '.commit.sha' "repos/${REPO}/branches/${{ inputs.branch }}")
+
+            export REPO_PAYLOAD=$(
+              jq -nc '{
+                "branch": env.BRANCH,
+                "date": env.DATE,
+                "sha": env.SHA
+              }'
+            )
+            PAYLOADS=$(jq -nc '(env.PAYLOADS|fromjson) + {(env.JUST_REPO): (env.REPO_PAYLOAD|fromjson)}')
+          done
+
+          # TODO: replace hardcoded branch w/ env.BRANCH after testing is complete
+          OBJ=$(
+            jq -nc '{
+              "branch": "update-workflows",
+              "payloads": (env.PAYLOADS|fromjson)
+            }'
+          )
+
+          echo "obj=${OBJ}" | tee --append ${GITHUB_OUTPUT}

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -13,77 +13,95 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  get-run-info:
-    uses: ./.github/workflows/get-run-info.yaml
-    secrets: inherit
-    with:
-      branch: branch-23.02
-      repos: >-
-        rapidsai/cudf
-        rapidsai/cuml
-        rapidsai/raft
-        rapidsai/rmm
+  # get-run-info:
+  #   uses: ./.github/workflows/get-run-info.yaml
+  #   secrets: inherit
+  #   with:
+  #     branch: branch-23.02
+  #     repos: >-
+  #       rapidsai/cudf
+  #       rapidsai/cuml
+  #       rapidsai/raft
+  #       rapidsai/rmm
   rmm-build:
-    needs: get-run-info
-    uses: rapidsai/rmm/.github/workflows/build.yaml@branch-23.02
-    secrets: inherit
-    with:
-      branch: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-      date: ${{ fromJSON(needs.get-run-info.outputs.obj).date }}
-      sha: ${{ fromJSON(needs.get-run-info.outputs.obj).shas.rmm }}
+    # needs: get-run-info
+    runs-on: ubuntu-latest
+    steps:
+      - uses: convictional/trigger-workflow-and-wait@v1.6.1
+        with:
+          owner: rapidsai
+          repo: rmm
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+          github_user: GPUtester
+          workflow_file_name: build.yaml
+          ref: update-workflows
+          wait_interval: 120
+          client_payload: '{"branch": "branch-23.02", "date": "2023-01-01", "sha": "10b1650c8be5fa88e29e7e487dbbdd50f0d920bc"}'
+          propagate_failure: false
+          trigger_workflow: true
+          wait_workflow: true
   rmm-tests:
-    needs: [get-run-info, rmm-build]
-    uses: rapidsai/rmm/.github/workflows/test.yaml@branch-23.02
-    secrets: inherit
-    with:
-      branch: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-      date: ${{ fromJSON(needs.get-run-info.outputs.obj).date }}
-      sha: ${{ fromJSON(needs.get-run-info.outputs.obj).shas.rmm }}
-  cudf-build:
-    needs: [get-run-info, rmm-build]
-    uses: rapidsai/cudf/.github/workflows/build.yaml@branch-23.02
-    secrets: inherit
-    with:
-      branch: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-      date: ${{ fromJSON(needs.get-run-info.outputs.obj).date }}
-      sha: ${{ fromJSON(needs.get-run-info.outputs.obj).shas.cudf }}
-  cudf-tests:
-    needs: [get-run-info, cudf-build]
-    uses: rapidsai/cudf/.github/workflows/test.yaml@branch-23.02
-    secrets: inherit
-    with:
-      branch: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-      date: ${{ fromJSON(needs.get-run-info.outputs.obj).date }}
-      sha: ${{ fromJSON(needs.get-run-info.outputs.obj).shas.cudf }}
-  raft-build:
-    needs: [get-run-info]
-    uses: rapidsai/raft/.github/workflows/build.yaml@branch-23.02
-    secrets: inherit
-    with:
-      branch: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-      date: ${{ fromJSON(needs.get-run-info.outputs.obj).date }}
-      sha: ${{ fromJSON(needs.get-run-info.outputs.obj).shas.raft }}
-  raft-tests:
-    needs: [get-run-info, raft-build]
-    uses: rapidsai/raft/.github/workflows/test.yaml@branch-23.02
-    secrets: inherit
-    with:
-      branch: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-      date: ${{ fromJSON(needs.get-run-info.outputs.obj).date }}
-      sha: ${{ fromJSON(needs.get-run-info.outputs.obj).shas.raft }}
-  cuml-build:
-    needs: [get-run-info, cudf-build]
-    uses: rapidsai/cuml/.github/workflows/build.yaml@branch-23.02
-    secrets: inherit
-    with:
-      branch: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-      date: ${{ fromJSON(needs.get-run-info.outputs.obj).date }}
-      sha: ${{ fromJSON(needs.get-run-info.outputs.obj).shas.cuml }}
-  cuml-tests:
-    needs: [get-run-info, cuml-build]
-    uses: rapidsai/cuml/.github/workflows/test.yaml@branch-23.02
-    secrets: inherit
-    with:
-      branch: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-      date: ${{ fromJSON(needs.get-run-info.outputs.obj).date }}
-      sha: ${{ fromJSON(needs.get-run-info.outputs.obj).shas.cuml }}
+    needs: [rmm-build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: convictional/trigger-workflow-and-wait@v1.6.1
+        with:
+          owner: rapidsai
+          repo: rmm
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+          github_user: GPUtester
+          workflow_file_name: test.yaml
+          ref: update-workflows
+          wait_interval: 120
+          client_payload: '{"branch": "branch-23.02", "date": "2023-01-01", "sha": "10b1650c8be5fa88e29e7e487dbbdd50f0d920bc"}'
+          propagate_failure: false
+          trigger_workflow: true
+          wait_workflow: true
+  # cudf-build:
+  #   needs: [get-run-info, rmm-build]
+  #   uses: rapidsai/cudf/.github/workflows/build.yaml@branch-23.02
+  #   secrets: inherit
+  #   with:
+  #     branch: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+  #     date: ${{ fromJSON(needs.get-run-info.outputs.obj).date }}
+  #     sha: ${{ fromJSON(needs.get-run-info.outputs.obj).shas.cudf }}
+  # cudf-tests:
+  #   needs: [get-run-info, cudf-build]
+  #   uses: rapidsai/cudf/.github/workflows/test.yaml@branch-23.02
+  #   secrets: inherit
+  #   with:
+  #     branch: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+  #     date: ${{ fromJSON(needs.get-run-info.outputs.obj).date }}
+  #     sha: ${{ fromJSON(needs.get-run-info.outputs.obj).shas.cudf }}
+  # raft-build:
+  #   needs: [get-run-info]
+  #   uses: rapidsai/raft/.github/workflows/build.yaml@branch-23.02
+  #   secrets: inherit
+  #   with:
+  #     branch: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+  #     date: ${{ fromJSON(needs.get-run-info.outputs.obj).date }}
+  #     sha: ${{ fromJSON(needs.get-run-info.outputs.obj).shas.raft }}
+  # raft-tests:
+  #   needs: [get-run-info, raft-build]
+  #   uses: rapidsai/raft/.github/workflows/test.yaml@branch-23.02
+  #   secrets: inherit
+  #   with:
+  #     branch: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+  #     date: ${{ fromJSON(needs.get-run-info.outputs.obj).date }}
+  #     sha: ${{ fromJSON(needs.get-run-info.outputs.obj).shas.raft }}
+  # cuml-build:
+  #   needs: [get-run-info, cudf-build]
+  #   uses: rapidsai/cuml/.github/workflows/build.yaml@branch-23.02
+  #   secrets: inherit
+  #   with:
+  #     branch: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+  #     date: ${{ fromJSON(needs.get-run-info.outputs.obj).date }}
+  #     sha: ${{ fromJSON(needs.get-run-info.outputs.obj).shas.cuml }}
+  # cuml-tests:
+  #   needs: [get-run-info, cuml-build]
+  #   uses: rapidsai/cuml/.github/workflows/test.yaml@branch-23.02
+  #   secrets: inherit
+  #   with:
+  #     branch: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+  #     date: ${{ fromJSON(needs.get-run-info.outputs.obj).date }}
+  #     sha: ${{ fromJSON(needs.get-run-info.outputs.obj).shas.cuml }}

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -13,18 +13,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # get-run-info:
-  #   uses: ./.github/workflows/get-run-info.yaml
-  #   secrets: inherit
-  #   with:
-  #     branch: branch-23.02
-  #     repos: >-
-  #       rapidsai/cudf
-  #       rapidsai/cuml
-  #       rapidsai/raft
-  #       rapidsai/rmm
+  get-run-info:
+    uses: ./.github/workflows/get-run-info-v2.yaml
+    secrets: inherit
+    with:
+      branch: branch-23.02
+      repos: >-
+        rapidsai/cudf
+        rapidsai/cuml
+        rapidsai/raft
+        rapidsai/rmm
   rmm-build:
-    # needs: get-run-info
+    needs: get-run-info
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -34,14 +34,14 @@ jobs:
           github_token: ${{ secrets.WORKFLOW_TOKEN }}
           github_user: GPUtester
           workflow_file_name: build.yaml
-          ref: update-workflows
+          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
           wait_interval: 30
-          client_payload: '{"branch": "branch-23.02", "date": "2023-01-01", "sha": "10b1650c8be5fa88e29e7e487dbbdd50f0d920bc"}'
+          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.rmm) }}
           propagate_failure: false
           trigger_workflow: true
           wait_workflow: true
   rmm-tests:
-    needs: [rmm-build]
+    needs: [get-run-info, rmm-build]
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -51,9 +51,9 @@ jobs:
           github_token: ${{ secrets.WORKFLOW_TOKEN }}
           github_user: GPUtester
           workflow_file_name: test.yaml
-          ref: update-workflows
+          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
           wait_interval: 30
-          client_payload: '{"branch": "branch-23.02", "date": "2023-01-01", "sha": "10b1650c8be5fa88e29e7e487dbbdd50f0d920bc"}'
+          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.rmm) }}
           propagate_failure: false
           trigger_workflow: true
           wait_workflow: true

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -27,7 +27,7 @@ jobs:
     # needs: get-run-info
     runs-on: ubuntu-latest
     steps:
-      - uses: convictional/trigger-workflow-and-wait@v1.6.1
+      - uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
           owner: rapidsai
           repo: rmm
@@ -44,7 +44,7 @@ jobs:
     needs: [rmm-build]
     runs-on: ubuntu-latest
     steps:
-      - uses: convictional/trigger-workflow-and-wait@v1.6.1
+      - uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
           owner: rapidsai
           repo: rmm

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -20,7 +20,11 @@ jobs:
       branch: branch-23.02
       repos: >-
         rapidsai/cudf
+        rapidsai/cugraph
         rapidsai/cuml
+        rapidsai/cusignal
+        rapidsai/cuspatial
+        rapidsai/cuxfilter
         rapidsai/raft
         rapidsai/rmm
   rmm-build:
@@ -57,51 +61,241 @@ jobs:
           propagate_failure: false
           trigger_workflow: true
           wait_workflow: true
-  # cudf-build:
-  #   needs: [get-run-info, rmm-build]
-  #   uses: rapidsai/cudf/.github/workflows/build.yaml@branch-23.02
-  #   secrets: inherit
-  #   with:
-  #     branch: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-  #     date: ${{ fromJSON(needs.get-run-info.outputs.obj).date }}
-  #     sha: ${{ fromJSON(needs.get-run-info.outputs.obj).shas.cudf }}
-  # cudf-tests:
-  #   needs: [get-run-info, cudf-build]
-  #   uses: rapidsai/cudf/.github/workflows/test.yaml@branch-23.02
-  #   secrets: inherit
-  #   with:
-  #     branch: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-  #     date: ${{ fromJSON(needs.get-run-info.outputs.obj).date }}
-  #     sha: ${{ fromJSON(needs.get-run-info.outputs.obj).shas.cudf }}
-  # raft-build:
-  #   needs: [get-run-info]
-  #   uses: rapidsai/raft/.github/workflows/build.yaml@branch-23.02
-  #   secrets: inherit
-  #   with:
-  #     branch: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-  #     date: ${{ fromJSON(needs.get-run-info.outputs.obj).date }}
-  #     sha: ${{ fromJSON(needs.get-run-info.outputs.obj).shas.raft }}
-  # raft-tests:
-  #   needs: [get-run-info, raft-build]
-  #   uses: rapidsai/raft/.github/workflows/test.yaml@branch-23.02
-  #   secrets: inherit
-  #   with:
-  #     branch: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-  #     date: ${{ fromJSON(needs.get-run-info.outputs.obj).date }}
-  #     sha: ${{ fromJSON(needs.get-run-info.outputs.obj).shas.raft }}
-  # cuml-build:
-  #   needs: [get-run-info, cudf-build]
-  #   uses: rapidsai/cuml/.github/workflows/build.yaml@branch-23.02
-  #   secrets: inherit
-  #   with:
-  #     branch: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-  #     date: ${{ fromJSON(needs.get-run-info.outputs.obj).date }}
-  #     sha: ${{ fromJSON(needs.get-run-info.outputs.obj).shas.cuml }}
-  # cuml-tests:
-  #   needs: [get-run-info, cuml-build]
-  #   uses: rapidsai/cuml/.github/workflows/test.yaml@branch-23.02
-  #   secrets: inherit
-  #   with:
-  #     branch: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-  #     date: ${{ fromJSON(needs.get-run-info.outputs.obj).date }}
-  #     sha: ${{ fromJSON(needs.get-run-info.outputs.obj).shas.cuml }}
+  cudf-build:
+    needs: [get-run-info, rmm-build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: rapidsai
+          repo: cudf
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+          github_user: GPUtester
+          workflow_file_name: build.yaml
+          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+          wait_interval: 30
+          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cudf) }}
+          propagate_failure: false
+          trigger_workflow: true
+          wait_workflow: true
+  cudf-tests:
+    needs: [get-run-info, cudf-build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: rapidsai
+          repo: cudf
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+          github_user: GPUtester
+          workflow_file_name: test.yaml
+          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+          wait_interval: 30
+          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cudf) }}
+          propagate_failure: false
+          trigger_workflow: true
+          wait_workflow: true
+  raft-build:
+    needs: [get-run-info, rmm-build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: rapidsai
+          repo: raft
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+          github_user: GPUtester
+          workflow_file_name: build.yaml
+          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+          wait_interval: 30
+          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.raft) }}
+          propagate_failure: false
+          trigger_workflow: true
+          wait_workflow: true
+  raft-tests:
+    needs: [get-run-info, raft-build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: rapidsai
+          repo: raft
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+          github_user: GPUtester
+          workflow_file_name: test.yaml
+          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+          wait_interval: 30
+          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.raft) }}
+          propagate_failure: false
+          trigger_workflow: true
+          wait_workflow: true
+  cuml-build:
+    needs: [get-run-info, cudf-build, raft-build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: rapidsai
+          repo: cuml
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+          github_user: GPUtester
+          workflow_file_name: build.yaml
+          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+          wait_interval: 30
+          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cuml) }}
+          propagate_failure: false
+          trigger_workflow: true
+          wait_workflow: true
+  cuml-tests:
+    needs: [get-run-info, cuml-build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: rapidsai
+          repo: cuml
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+          github_user: GPUtester
+          workflow_file_name: test.yaml
+          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+          wait_interval: 30
+          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cuml) }}
+          propagate_failure: false
+          trigger_workflow: true
+          wait_workflow: true
+  cugraph-build:
+    needs: [get-run-info, cudf-build, raft-build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: rapidsai
+          repo: cugraph
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+          github_user: GPUtester
+          workflow_file_name: build.yaml
+          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+          wait_interval: 30
+          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cugraph) }}
+          propagate_failure: false
+          trigger_workflow: true
+          wait_workflow: true
+  cugraph-tests:
+    needs: [get-run-info, cugraph-build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: rapidsai
+          repo: cugraph
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+          github_user: GPUtester
+          workflow_file_name: test.yaml
+          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+          wait_interval: 30
+          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cugraph) }}
+          propagate_failure: false
+          trigger_workflow: true
+          wait_workflow: true
+  cusignal-build:
+    needs: [get-run-info]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: rapidsai
+          repo: cusignal
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+          github_user: GPUtester
+          workflow_file_name: build.yaml
+          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+          wait_interval: 30
+          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cusignal) }}
+          propagate_failure: false
+          trigger_workflow: true
+          wait_workflow: true
+  cusignal-tests:
+    needs: [get-run-info, cusignal-build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: rapidsai
+          repo: cusignal
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+          github_user: GPUtester
+          workflow_file_name: test.yaml
+          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+          wait_interval: 30
+          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cusignal) }}
+          propagate_failure: false
+          trigger_workflow: true
+          wait_workflow: true
+  cuspatial-build:
+    needs: [get-run-info, cudf-build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: rapidsai
+          repo: cuspatial
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+          github_user: GPUtester
+          workflow_file_name: build.yaml
+          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+          wait_interval: 30
+          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cuspatial) }}
+          propagate_failure: false
+          trigger_workflow: true
+          wait_workflow: true
+  cuspatial-tests:
+    needs: [get-run-info, cuspatial-build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: rapidsai
+          repo: cuspatial
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+          github_user: GPUtester
+          workflow_file_name: test.yaml
+          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+          wait_interval: 30
+          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cuspatial) }}
+          propagate_failure: false
+          trigger_workflow: true
+          wait_workflow: true
+  cuxfilter-build:
+    needs: [get-run-info, cudf-build, cuspatial-build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: rapidsai
+          repo: cuxfilter
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+          github_user: GPUtester
+          workflow_file_name: build.yaml
+          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+          wait_interval: 30
+          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cuxfilter) }}
+          propagate_failure: false
+          trigger_workflow: true
+          wait_workflow: true
+  cuxfilter-tests:
+    needs: [get-run-info, cuxfilter-build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: rapidsai
+          repo: cuxfilter
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+          github_user: GPUtester
+          workflow_file_name: test.yaml
+          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+          wait_interval: 30
+          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cuxfilter) }}
+          propagate_failure: false
+          trigger_workflow: true
+          wait_workflow: true

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -35,7 +35,7 @@ jobs:
           github_user: GPUtester
           workflow_file_name: build.yaml
           ref: update-workflows
-          wait_interval: 120
+          wait_interval: 30
           client_payload: '{"branch": "branch-23.02", "date": "2023-01-01", "sha": "10b1650c8be5fa88e29e7e487dbbdd50f0d920bc"}'
           propagate_failure: false
           trigger_workflow: true
@@ -52,7 +52,7 @@ jobs:
           github_user: GPUtester
           workflow_file_name: test.yaml
           ref: update-workflows
-          wait_interval: 120
+          wait_interval: 30
           client_payload: '{"branch": "branch-23.02", "date": "2023-01-01", "sha": "10b1650c8be5fa88e29e7e487dbbdd50f0d920bc"}'
           propagate_failure: false
           trigger_workflow: true


### PR DESCRIPTION
## Problem

I originally set up the `nightly-pipeline.yaml` workflow to utilize the reusable `build.yaml` and `test.yaml` workflows that exist in each repository. 

However, after adding several repositories to the `nightly-pipeline.yaml` workflow, I encountered the `workflow reference count` error shown below ([log link](https://github.com/rapidsai/actions/actions/runs/3820388301)).

This limit is described in GitHub's [reusable workflow docs](https://docs.github.com/en/actions/using-workflows/reusing-workflows#limitations).

![image](https://user-images.githubusercontent.com/7400326/210273322-3771f3b9-a5a4-4d9e-8d6d-52fe329403bf.png)

## Solution

To workaround this problem, I replaced the reusable workflows with individual jobs that use the [trigger-workflow-and-wait](https://github.com/convictional/trigger-workflow-and-wait/) composite action.

The `trigger-workflow-and-wait` action triggers a workflow that's configured for `workflow_dispatch` events and (unlike triggering the event manually) will wait for the triggered workflow to complete.

## Potential Future Improvements

It'd be nice to have the child workflows' statuses reported to this top-level nightly workflow.

To accomplish this, we could set the `propagate_failure` value on the action to `true`.

This would probably also require that we add an `if: always()` expression to the downstream jobs in this workflow so that they run nightly builds/tests regardless of the upstream job statuses.

## Additional Changes

This PR also adds all of the latest repositories that have been onboarded to GitHub Actions to this nightly workflow.