### PR TITLE
Add `dask-cuda` to nightly pipeline

### DIFF
--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -25,6 +25,7 @@ jobs:
         rapidsai/cusignal
         rapidsai/cuspatial
         rapidsai/cuxfilter
+        rapidsai/dask-cuda
         rapidsai/raft
         rapidsai/rmm
   rmm-build:
@@ -62,7 +63,7 @@ jobs:
           trigger_workflow: true
           wait_workflow: true
   cudf-build:
-    needs: [get-run-info, rmm-build]
+    needs: [get-run-info, rmm-build, dask-cuda-build]
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -96,7 +97,7 @@ jobs:
           trigger_workflow: true
           wait_workflow: true
   raft-build:
-    needs: [get-run-info, rmm-build]
+    needs: [get-run-info, rmm-build, dask-cuda-build]
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -164,7 +165,7 @@ jobs:
           trigger_workflow: true
           wait_workflow: true
   cugraph-build:
-    needs: [get-run-info, cudf-build, raft-build]
+    needs: [get-run-info, cudf-build, raft-build, dask-cuda-build]
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -266,7 +267,7 @@ jobs:
           trigger_workflow: true
           wait_workflow: true
   cuxfilter-build:
-    needs: [get-run-info, cudf-build, cuspatial-build]
+    needs: [get-run-info, cudf-build, cuspatial-build, dask-cuda-build]
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -296,6 +297,40 @@ jobs:
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
           wait_interval: 30
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cuxfilter) }}
+          propagate_failure: false
+          trigger_workflow: true
+          wait_workflow: true
+  dask-cuda-build:
+    needs: [get-run-info]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: rapidsai
+          repo: dask-cuda
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+          github_user: GPUtester
+          workflow_file_name: build.yaml
+          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+          wait_interval: 30
+          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.dask-cuda) }}
+          propagate_failure: false
+          trigger_workflow: true
+          wait_workflow: true
+  dask-cuda-tests:
+    needs: [get-run-info, dask-cuda-build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: rapidsai
+          repo: dask-cuda
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+          github_user: GPUtester
+          workflow_file_name: test.yaml
+          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+          wait_interval: 30
+          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.dask-cuda) }}
           propagate_failure: false
           trigger_workflow: true
           wait_workflow: true

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -40,7 +40,7 @@ jobs:
           github_user: GPUtester
           workflow_file_name: build.yaml
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-          wait_interval: 30
+          wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.rmm) }}
           propagate_failure: false
           trigger_workflow: true
@@ -57,7 +57,7 @@ jobs:
           github_user: GPUtester
           workflow_file_name: test.yaml
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-          wait_interval: 30
+          wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.rmm) }}
           propagate_failure: false
           trigger_workflow: true
@@ -74,7 +74,7 @@ jobs:
           github_user: GPUtester
           workflow_file_name: build.yaml
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-          wait_interval: 30
+          wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cudf) }}
           propagate_failure: false
           trigger_workflow: true
@@ -91,7 +91,7 @@ jobs:
           github_user: GPUtester
           workflow_file_name: test.yaml
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-          wait_interval: 30
+          wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cudf) }}
           propagate_failure: false
           trigger_workflow: true
@@ -108,7 +108,7 @@ jobs:
           github_user: GPUtester
           workflow_file_name: build.yaml
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-          wait_interval: 30
+          wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.raft) }}
           propagate_failure: false
           trigger_workflow: true
@@ -125,7 +125,7 @@ jobs:
           github_user: GPUtester
           workflow_file_name: test.yaml
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-          wait_interval: 30
+          wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.raft) }}
           propagate_failure: false
           trigger_workflow: true
@@ -142,7 +142,7 @@ jobs:
           github_user: GPUtester
           workflow_file_name: build.yaml
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-          wait_interval: 30
+          wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cuml) }}
           propagate_failure: false
           trigger_workflow: true
@@ -159,7 +159,7 @@ jobs:
           github_user: GPUtester
           workflow_file_name: test.yaml
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-          wait_interval: 30
+          wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cuml) }}
           propagate_failure: false
           trigger_workflow: true
@@ -176,7 +176,7 @@ jobs:
           github_user: GPUtester
           workflow_file_name: build.yaml
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-          wait_interval: 30
+          wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cugraph) }}
           propagate_failure: false
           trigger_workflow: true
@@ -193,7 +193,7 @@ jobs:
           github_user: GPUtester
           workflow_file_name: test.yaml
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-          wait_interval: 30
+          wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cugraph) }}
           propagate_failure: false
           trigger_workflow: true
@@ -210,7 +210,7 @@ jobs:
           github_user: GPUtester
           workflow_file_name: build.yaml
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-          wait_interval: 30
+          wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cusignal) }}
           propagate_failure: false
           trigger_workflow: true
@@ -227,7 +227,7 @@ jobs:
           github_user: GPUtester
           workflow_file_name: test.yaml
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-          wait_interval: 30
+          wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cusignal) }}
           propagate_failure: false
           trigger_workflow: true
@@ -244,7 +244,7 @@ jobs:
           github_user: GPUtester
           workflow_file_name: build.yaml
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-          wait_interval: 30
+          wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cuspatial) }}
           propagate_failure: false
           trigger_workflow: true
@@ -261,7 +261,7 @@ jobs:
           github_user: GPUtester
           workflow_file_name: test.yaml
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-          wait_interval: 30
+          wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cuspatial) }}
           propagate_failure: false
           trigger_workflow: true
@@ -278,7 +278,7 @@ jobs:
           github_user: GPUtester
           workflow_file_name: build.yaml
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-          wait_interval: 30
+          wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cuxfilter) }}
           propagate_failure: false
           trigger_workflow: true
@@ -295,7 +295,7 @@ jobs:
           github_user: GPUtester
           workflow_file_name: test.yaml
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-          wait_interval: 30
+          wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cuxfilter) }}
           propagate_failure: false
           trigger_workflow: true
@@ -312,7 +312,7 @@ jobs:
           github_user: GPUtester
           workflow_file_name: build.yaml
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-          wait_interval: 30
+          wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.dask-cuda) }}
           propagate_failure: false
           trigger_workflow: true
@@ -329,7 +329,7 @@ jobs:
           github_user: GPUtester
           workflow_file_name: test.yaml
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-          wait_interval: 30
+          wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.dask-cuda) }}
           propagate_failure: false
           trigger_workflow: true


### PR DESCRIPTION
This PR adds `dask-cuda` to our nightly pipeline.

The `dask-cuda` build doesn't depend on any other libraries and therefore will run at the beginning of the pipeline.

Since `cudf`, `raft`, `cugraph`, and `cuxfilter` depend on `dask-cuda`, the `dask-cuda-build` job has been added as dependencies of their jobs.

This PR also updates the `wait_interval` to `120` seconds.

The `wait_internal` controls how often downstream jobs are queried for completion via the GitHub API.

I increased its value to preemptively prevent us from hitting any API rate limits as we add more jobs to this pipeline.