### PR TITLE
Add raft ucx dependency

### DIFF
--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -101,7 +101,7 @@ jobs:
           trigger_workflow: true
           wait_workflow: true
   raft-build:
-    needs: [get-run-info, rmm-build, dask-cuda-build, ucx-py-build]
+    needs: [get-run-info, rmm-build, dask-cuda-build]
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -118,7 +118,7 @@ jobs:
           trigger_workflow: true
           wait_workflow: true
   raft-tests:
-    needs: [get-run-info, raft-build]
+    needs: [get-run-info, raft-build, ucx-py-tests]
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -101,7 +101,7 @@ jobs:
           trigger_workflow: true
           wait_workflow: true
   raft-build:
-    needs: [get-run-info, rmm-build, dask-cuda-build]
+    needs: [get-run-info, rmm-build, dask-cuda-build, ucx-py-build]
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -118,7 +118,7 @@ jobs:
           trigger_workflow: true
           wait_workflow: true
   raft-tests:
-    needs: [get-run-info, raft-build, ucx-py-tests]
+    needs: [get-run-info, raft-build, ucx-py-build]
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5


### PR DESCRIPTION
ucx-py is required by raft-dask at runtime, so raft-tests require ucx-py's tests to have passed.