### PR TITLE
Update nightly pipeline to reflect downstream job status

### DIFF
--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -51,6 +51,7 @@ jobs:
           wait_workflow: true
   rmm-tests:
     needs: [get-run-info, rmm-build]
+    if: ${{ needs.rmm-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -85,6 +86,7 @@ jobs:
           wait_workflow: true
   cudf-tests:
     needs: [get-run-info, cudf-build]
+    if: ${{ needs.cudf-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -119,6 +121,7 @@ jobs:
           wait_workflow: true
   raft-tests:
     needs: [get-run-info, raft-build, ucx-py-build]
+    if: ${{ needs.raft-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -153,6 +156,7 @@ jobs:
           wait_workflow: true
   cuml-tests:
     needs: [get-run-info, cuml-build]
+    if: ${{ needs.cuml-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -187,6 +191,7 @@ jobs:
           wait_workflow: true
   cugraph-tests:
     needs: [get-run-info, cugraph-build]
+    if: ${{ needs.cugraph-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -221,6 +226,7 @@ jobs:
           wait_workflow: true
   cusignal-tests:
     needs: [get-run-info, cusignal-build]
+    if: ${{ needs.cusignal-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -255,6 +261,7 @@ jobs:
           wait_workflow: true
   cuspatial-tests:
     needs: [get-run-info, cuspatial-build]
+    if: ${{ needs.cuspatial-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -289,6 +296,7 @@ jobs:
           wait_workflow: true
   cuxfilter-tests:
     needs: [get-run-info, cuxfilter-build]
+    if: ${{ needs.cuxfilter-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -323,6 +331,7 @@ jobs:
           wait_workflow: true
   dask-cuda-tests:
     needs: [get-run-info, dask-cuda-build]
+    if: ${{ needs.dask-cuda-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -357,6 +366,7 @@ jobs:
           wait_workflow: true
   ucx-py-tests:
     needs: [get-run-info, ucx-py-build]
+    if: ${{ needs.ucx-py-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -391,6 +401,7 @@ jobs:
           wait_workflow: true
   cugraph-ops-tests:
     needs: [get-run-info, cugraph-ops-build]
+    if: ${{ needs.cugraph-ops-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -425,6 +436,7 @@ jobs:
           wait_workflow: true
   cucim-tests:
     needs: [get-run-info, cucim-build]
+    if: ${{ needs.cucim-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -51,7 +51,6 @@ jobs:
           wait_workflow: true
   rmm-tests:
     needs: [get-run-info, rmm-build]
-    if: ${{ needs.rmm-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -86,7 +85,6 @@ jobs:
           wait_workflow: true
   cudf-tests:
     needs: [get-run-info, cudf-build]
-    if: ${{ needs.cudf-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -121,7 +119,6 @@ jobs:
           wait_workflow: true
   raft-tests:
     needs: [get-run-info, raft-build, ucx-py-build]
-    if: ${{ needs.raft-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -156,7 +153,6 @@ jobs:
           wait_workflow: true
   cuml-tests:
     needs: [get-run-info, cuml-build]
-    if: ${{ needs.cuml-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -191,7 +187,6 @@ jobs:
           wait_workflow: true
   cugraph-tests:
     needs: [get-run-info, cugraph-build]
-    if: ${{ needs.cugraph-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -226,7 +221,6 @@ jobs:
           wait_workflow: true
   cusignal-tests:
     needs: [get-run-info, cusignal-build]
-    if: ${{ needs.cusignal-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -261,7 +255,6 @@ jobs:
           wait_workflow: true
   cuspatial-tests:
     needs: [get-run-info, cuspatial-build]
-    if: ${{ needs.cuspatial-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -296,7 +289,6 @@ jobs:
           wait_workflow: true
   cuxfilter-tests:
     needs: [get-run-info, cuxfilter-build]
-    if: ${{ needs.cuxfilter-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -331,7 +323,6 @@ jobs:
           wait_workflow: true
   dask-cuda-tests:
     needs: [get-run-info, dask-cuda-build]
-    if: ${{ needs.dask-cuda-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -366,7 +357,6 @@ jobs:
           wait_workflow: true
   ucx-py-tests:
     needs: [get-run-info, ucx-py-build]
-    if: ${{ needs.ucx-py-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -401,7 +391,6 @@ jobs:
           wait_workflow: true
   cugraph-ops-tests:
     needs: [get-run-info, cugraph-ops-build]
-    if: ${{ needs.cugraph-ops-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -436,7 +425,6 @@ jobs:
           wait_workflow: true
   cucim-tests:
     needs: [get-run-info, cucim-build]
-    if: ${{ needs.cucim-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -46,7 +46,7 @@ jobs:
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.rmm) }}
-          propagate_failure: false
+          propagate_failure: true
           trigger_workflow: true
           wait_workflow: true
   rmm-tests:
@@ -63,7 +63,7 @@ jobs:
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.rmm) }}
-          propagate_failure: false
+          propagate_failure: true
           trigger_workflow: true
           wait_workflow: true
   cudf-build:
@@ -80,7 +80,7 @@ jobs:
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cudf) }}
-          propagate_failure: false
+          propagate_failure: true
           trigger_workflow: true
           wait_workflow: true
   cudf-tests:
@@ -97,7 +97,7 @@ jobs:
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cudf) }}
-          propagate_failure: false
+          propagate_failure: true
           trigger_workflow: true
           wait_workflow: true
   raft-build:
@@ -114,7 +114,7 @@ jobs:
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.raft) }}
-          propagate_failure: false
+          propagate_failure: true
           trigger_workflow: true
           wait_workflow: true
   raft-tests:
@@ -131,7 +131,7 @@ jobs:
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.raft) }}
-          propagate_failure: false
+          propagate_failure: true
           trigger_workflow: true
           wait_workflow: true
   cuml-build:
@@ -148,7 +148,7 @@ jobs:
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cuml) }}
-          propagate_failure: false
+          propagate_failure: true
           trigger_workflow: true
           wait_workflow: true
   cuml-tests:
@@ -165,7 +165,7 @@ jobs:
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cuml) }}
-          propagate_failure: false
+          propagate_failure: true
           trigger_workflow: true
           wait_workflow: true
   cugraph-build:
@@ -182,7 +182,7 @@ jobs:
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cugraph) }}
-          propagate_failure: false
+          propagate_failure: true
           trigger_workflow: true
           wait_workflow: true
   cugraph-tests:
@@ -199,7 +199,7 @@ jobs:
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cugraph) }}
-          propagate_failure: false
+          propagate_failure: true
           trigger_workflow: true
           wait_workflow: true
   cusignal-build:
@@ -216,7 +216,7 @@ jobs:
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cusignal) }}
-          propagate_failure: false
+          propagate_failure: true
           trigger_workflow: true
           wait_workflow: true
   cusignal-tests:
@@ -233,7 +233,7 @@ jobs:
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cusignal) }}
-          propagate_failure: false
+          propagate_failure: true
           trigger_workflow: true
           wait_workflow: true
   cuspatial-build:
@@ -250,7 +250,7 @@ jobs:
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cuspatial) }}
-          propagate_failure: false
+          propagate_failure: true
           trigger_workflow: true
           wait_workflow: true
   cuspatial-tests:
@@ -267,7 +267,7 @@ jobs:
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cuspatial) }}
-          propagate_failure: false
+          propagate_failure: true
           trigger_workflow: true
           wait_workflow: true
   cuxfilter-build:
@@ -284,7 +284,7 @@ jobs:
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cuxfilter) }}
-          propagate_failure: false
+          propagate_failure: true
           trigger_workflow: true
           wait_workflow: true
   cuxfilter-tests:
@@ -301,7 +301,7 @@ jobs:
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cuxfilter) }}
-          propagate_failure: false
+          propagate_failure: true
           trigger_workflow: true
           wait_workflow: true
   dask-cuda-build:
@@ -318,7 +318,7 @@ jobs:
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.dask-cuda) }}
-          propagate_failure: false
+          propagate_failure: true
           trigger_workflow: true
           wait_workflow: true
   dask-cuda-tests:
@@ -335,7 +335,7 @@ jobs:
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.dask-cuda) }}
-          propagate_failure: false
+          propagate_failure: true
           trigger_workflow: true
           wait_workflow: true
   ucx-py-build:
@@ -352,7 +352,7 @@ jobs:
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).ucx-py-branch }}
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.ucx-py) }}
-          propagate_failure: false
+          propagate_failure: true
           trigger_workflow: true
           wait_workflow: true
   ucx-py-tests:
@@ -369,7 +369,7 @@ jobs:
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).ucx-py-branch }}
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.ucx-py) }}
-          propagate_failure: false
+          propagate_failure: true
           trigger_workflow: true
           wait_workflow: true
   cugraph-ops-build:
@@ -386,7 +386,7 @@ jobs:
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cugraph-ops) }}
-          propagate_failure: false
+          propagate_failure: true
           trigger_workflow: true
           wait_workflow: true
   cugraph-ops-tests:
@@ -403,7 +403,7 @@ jobs:
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cugraph-ops) }}
-          propagate_failure: false
+          propagate_failure: true
           trigger_workflow: true
           wait_workflow: true
   cucim-build:
@@ -420,7 +420,7 @@ jobs:
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cucim) }}
-          propagate_failure: false
+          propagate_failure: true
           trigger_workflow: true
           wait_workflow: true
   cucim-tests:
@@ -437,7 +437,7 @@ jobs:
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cucim) }}
-          propagate_failure: false
+          propagate_failure: true
           trigger_workflow: true
           wait_workflow: true
   cumlprims_mg-build:
@@ -454,6 +454,6 @@ jobs:
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cumlprims_mg) }}
-          propagate_failure: false
+          propagate_failure: true
           trigger_workflow: true
           wait_workflow: true

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -69,6 +69,7 @@ jobs:
   cudf-build:
     needs: [get-run-info, rmm-build, dask-cuda-build]
     runs-on: ubuntu-latest
+    if: ${{ !cancelled() }}
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
@@ -103,6 +104,7 @@ jobs:
   raft-build:
     needs: [get-run-info, rmm-build, dask-cuda-build]
     runs-on: ubuntu-latest
+    if: ${{ !cancelled() }}
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
@@ -137,6 +139,7 @@ jobs:
   cuml-build:
     needs: [get-run-info, cudf-build, raft-build]
     runs-on: ubuntu-latest
+    if: ${{ !cancelled() }}
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
@@ -171,6 +174,7 @@ jobs:
   cugraph-build:
     needs: [get-run-info, cudf-build, raft-build, dask-cuda-build]
     runs-on: ubuntu-latest
+    if: ${{ !cancelled() }}
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
@@ -205,6 +209,7 @@ jobs:
   cusignal-build:
     needs: [get-run-info]
     runs-on: ubuntu-latest
+    if: ${{ !cancelled() }}
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
@@ -239,6 +244,7 @@ jobs:
   cuspatial-build:
     needs: [get-run-info, cudf-build]
     runs-on: ubuntu-latest
+    if: ${{ !cancelled() }}
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
@@ -273,6 +279,7 @@ jobs:
   cuxfilter-build:
     needs: [get-run-info, cudf-build, cuspatial-build, dask-cuda-build]
     runs-on: ubuntu-latest
+    if: ${{ !cancelled() }}
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
@@ -307,6 +314,7 @@ jobs:
   dask-cuda-build:
     needs: [get-run-info]
     runs-on: ubuntu-latest
+    if: ${{ !cancelled() }}
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
@@ -341,6 +349,7 @@ jobs:
   ucx-py-build:
     needs: get-run-info
     runs-on: ubuntu-latest
+    if: ${{ !cancelled() }}
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
@@ -375,6 +384,7 @@ jobs:
   cugraph-ops-build:
     needs: [get-run-info, rmm-build, raft-build]
     runs-on: ubuntu-latest
+    if: ${{ !cancelled() }}
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
@@ -443,6 +453,7 @@ jobs:
   cumlprims_mg-build:
     needs: [get-run-info, raft-build]
     runs-on: ubuntu-latest
+    if: ${{ !cancelled() }}
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:


### PR DESCRIPTION
Updates the workflow to actually reflect the resultant status of the downstream jobs that are triggered:

- downstream test jobs will only run if the corresponding build job succeeds (e.g. rmm-tests only run if rmm-build succeeds)


Note: downstream build jobs should still always run even if upstream build jobs fail (e.g. cudf-build runs even if rmm-build fails)