### PR TITLE
Add `ucxx` to nightly workflow

### DIFF
--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -31,6 +31,7 @@ jobs:
         rapidsai/dask-cuda
         rapidsai/raft
         rapidsai/rmm
+        rapidsai/ucxx
         rapidsai/ucx-py
   rmm-build:
     needs: get-run-info
@@ -455,5 +456,40 @@ jobs:
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cumlprims_mg) }}
           propagate_failure: false
+          trigger_workflow: true
+          wait_workflow: true
+  ucxx-build:
+      needs: [get-run-info, rmm-build]
+      runs-on: ubuntu-latest
+      if: ${{ !cancelled() }}
+      steps:
+        - uses: convictional/trigger-workflow-and-wait@v1.6.5
+          with:
+            owner: rapidsai
+            repo: ucxx
+            github_token: ${{ secrets.WORKFLOW_TOKEN }}
+            github_user: GPUtester
+            workflow_file_name: build.yaml
+            ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+            wait_interval: 120
+            client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.ucxx) }}
+            propagate_failure: true
+            trigger_workflow: true
+            wait_workflow: true
+  ucxx-tests:
+    needs: [get-run-info, ucxx-build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: rapidsai
+          repo: ucxx
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+          github_user: GPUtester
+          workflow_file_name: test.yaml
+          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+          wait_interval: 120
+          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.ucxx) }}
+          propagate_failure: true
           trigger_workflow: true
           wait_workflow: true


### PR DESCRIPTION
This PR adds `ucxx` to the nightly pipeline.

The library depends on `rmm` therefore the `rmm` job has been added to the `ucxx`'s job's `needs` list.