### PR TITLE
Set `ucxx` branch in run-info job

### DIFF
--- a/.github/workflows/get-run-info.yaml
+++ b/.github/workflows/get-run-info.yaml
@@ -59,7 +59,7 @@ jobs:
             export JUST_REPO=${REPO##*/} # removes GH organization
             export BRANCH="${RAPIDS_BRANCH}"
 
-            if [ "${JUST_REPO}" = "ucx-py" ]; then
+            if [ "${JUST_REPO}" = "ucx-py" ] || [ "${JUST_REPO}" = "ucxx" ]; then
               export BRANCH="${UCX_PY_BRANCH}"
             fi
 

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -470,23 +470,23 @@ jobs:
           trigger_workflow: true
           wait_workflow: true
   ucxx-build:
-      needs: [get-run-info, rmm-build]
-      runs-on: ubuntu-latest
-      if: ${{ !cancelled() }}
-      steps:
-        - uses: convictional/trigger-workflow-and-wait@v1.6.5
-          with:
-            owner: rapidsai
-            repo: ucxx
-            github_token: ${{ secrets.WORKFLOW_TOKEN }}
-            github_user: GPUtester
-            workflow_file_name: build.yaml
-            ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-            wait_interval: 120
-            client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.ucxx) }}
-            propagate_failure: true
-            trigger_workflow: true
-            wait_workflow: true
+    needs: [get-run-info, rmm-build]
+    runs-on: ubuntu-latest
+    if: ${{ !cancelled() }}
+    steps:
+      - uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: rapidsai
+          repo: ucxx
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+          github_user: GPUtester
+          workflow_file_name: build.yaml
+          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).ucx-py-branch }}
+          wait_interval: 120
+          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.ucxx) }}
+          propagate_failure: true
+          trigger_workflow: true
+          wait_workflow: true
   ucxx-tests:
     needs: [get-run-info, ucxx-build]
     runs-on: ubuntu-latest
@@ -498,7 +498,7 @@ jobs:
           github_token: ${{ secrets.WORKFLOW_TOKEN }}
           github_user: GPUtester
           workflow_file_name: test.yaml
-          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).ucx-py-branch }}
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.ucxx) }}
           propagate_failure: true


### PR DESCRIPTION
PR sets the correct `BRANCH` variable in the `get-run-info` script when the repository is `ucxx`