### PR TITLE
Run tests when build jobs pass

### DIFF
--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -52,6 +52,7 @@ jobs:
           wait_workflow: true
   rmm-tests:
     needs: [get-run-info, rmm-build]
+    if: ${{ needs.rmm-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -87,6 +88,7 @@ jobs:
           wait_workflow: true
   cudf-tests:
     needs: [get-run-info, cudf-build]
+    if: ${{ needs.cudf-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -122,6 +124,7 @@ jobs:
           wait_workflow: true
   raft-tests:
     needs: [get-run-info, raft-build, ucx-py-build]
+    if: ${{ needs.raft-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -157,6 +160,7 @@ jobs:
           wait_workflow: true
   cuml-tests:
     needs: [get-run-info, cuml-build]
+    if: ${{ needs.cuml-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -192,6 +196,7 @@ jobs:
           wait_workflow: true
   cugraph-tests:
     needs: [get-run-info, cugraph-build]
+    if: ${{ needs.cugraph-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -227,6 +232,7 @@ jobs:
           wait_workflow: true
   cusignal-tests:
     needs: [get-run-info, cusignal-build]
+    if: ${{ needs.cusignal-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -262,6 +268,7 @@ jobs:
           wait_workflow: true
   cuspatial-tests:
     needs: [get-run-info, cuspatial-build]
+    if: ${{ needs.cuspatial-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -297,6 +304,7 @@ jobs:
           wait_workflow: true
   cuxfilter-tests:
     needs: [get-run-info, cuxfilter-build]
+    if: ${{ needs.cuxfilter-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -332,6 +340,7 @@ jobs:
           wait_workflow: true
   dask-cuda-tests:
     needs: [get-run-info, dask-cuda-build]
+    if: ${{ needs.dask-cuda-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -367,6 +376,7 @@ jobs:
           wait_workflow: true
   ucx-py-tests:
     needs: [get-run-info, ucx-py-build]
+    if: ${{ needs.ucx-py-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -402,6 +412,7 @@ jobs:
           wait_workflow: true
   cugraph-ops-tests:
     needs: [get-run-info, cugraph-ops-build]
+    if: ${{ needs.cugraph-ops-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -436,6 +447,7 @@ jobs:
           wait_workflow: true
   cucim-tests:
     needs: [get-run-info, cucim-build]
+    if: ${{ needs.cucim-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -489,6 +501,7 @@ jobs:
           wait_workflow: true
   ucxx-tests:
     needs: [get-run-info, ucxx-build]
+    if: ${{ needs.ucxx-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5


### PR DESCRIPTION
Test jobs currently do not run except all previous jobs pass. The desired workflow is that the tests should always run when the build jobs they immediately depend on, succeed.