### PR TITLE
Make tests run when builds pass

### DIFF
--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -88,7 +88,7 @@ jobs:
           wait_workflow: true
   cudf-tests:
     needs: [get-run-info, cudf-build]
-    if: ${{ needs.cudf-build.result == 'success' }}
+    if: ${{ needs.cudf-build.result == 'success' && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -124,7 +124,7 @@ jobs:
           wait_workflow: true
   raft-tests:
     needs: [get-run-info, raft-build, ucx-py-build]
-    if: ${{ needs.raft-build.result == 'success' }}
+    if: ${{ needs.raft-build.result == 'success' && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -160,7 +160,7 @@ jobs:
           wait_workflow: true
   cuml-tests:
     needs: [get-run-info, cuml-build]
-    if: ${{ needs.cuml-build.result == 'success' }}
+    if: ${{ needs.cuml-build.result == 'success' && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -196,7 +196,7 @@ jobs:
           wait_workflow: true
   cugraph-tests:
     needs: [get-run-info, cugraph-build]
-    if: ${{ needs.cugraph-build.result == 'success' }}
+    if: ${{ needs.cugraph-build.result == 'success' && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -232,7 +232,7 @@ jobs:
           wait_workflow: true
   cusignal-tests:
     needs: [get-run-info, cusignal-build]
-    if: ${{ needs.cusignal-build.result == 'success' }}
+    if: ${{ needs.cusignal-build.result == 'success' && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -268,7 +268,7 @@ jobs:
           wait_workflow: true
   cuspatial-tests:
     needs: [get-run-info, cuspatial-build]
-    if: ${{ needs.cuspatial-build.result == 'success' }}
+    if: ${{ needs.cuspatial-build.result == 'success' && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -304,7 +304,7 @@ jobs:
           wait_workflow: true
   cuxfilter-tests:
     needs: [get-run-info, cuxfilter-build]
-    if: ${{ needs.cuxfilter-build.result == 'success' }}
+    if: ${{ needs.cuxfilter-build.result == 'success' && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -340,7 +340,7 @@ jobs:
           wait_workflow: true
   dask-cuda-tests:
     needs: [get-run-info, dask-cuda-build]
-    if: ${{ needs.dask-cuda-build.result == 'success' }}
+    if: ${{ needs.dask-cuda-build.result == 'success' && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -376,7 +376,7 @@ jobs:
           wait_workflow: true
   ucx-py-tests:
     needs: [get-run-info, ucx-py-build]
-    if: ${{ needs.ucx-py-build.result == 'success' }}
+    if: ${{ needs.ucx-py-build.result == 'success' && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -412,7 +412,7 @@ jobs:
           wait_workflow: true
   cugraph-ops-tests:
     needs: [get-run-info, cugraph-ops-build]
-    if: ${{ needs.cugraph-ops-build.result == 'success' }}
+    if: ${{ needs.cugraph-ops-build.result == 'success' && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -447,7 +447,7 @@ jobs:
           wait_workflow: true
   cucim-tests:
     needs: [get-run-info, cucim-build]
-    if: ${{ needs.cucim-build.result == 'success' }}
+    if: ${{ needs.cucim-build.result == 'success' && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -501,7 +501,7 @@ jobs:
           wait_workflow: true
   ucxx-tests:
     needs: [get-run-info, ucxx-build]
-    if: ${{ needs.ucxx-build.result == 'success' }}
+    if: ${{ needs.ucxx-build.result == 'success' && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5


### PR DESCRIPTION
Currently, tests get skipped if a transitive dependency fails; it is not clear why this is the case, given the applied condition of `if: ${{ needs.<job-id>.result == 'success' }}` for the test jobs. 

For instance, `cudf-tests` depend on `cudf-build`, which depends on `rmm-build` -- now if `rmm-build` fails, even if `cudf-build` passes, `cudf-tests` inevitably get skipped. See [this example](https://github.com/rapidsai/actions/actions/runs/4868448744).

This is not the desired workflow. The desired workflow is to have the test jobs run as long as their immediate build dependencies pass. This PR ensures this.

[This workflow](https://github.com/AyodeAwe/testing/actions/runs/4888641367) demonstrates this change.