### PR TITLE
Update Nightly Pipeline

### DIFF
--- a/.github/workflows/get-run-info.yaml
+++ b/.github/workflows/get-run-info.yaml
@@ -33,6 +33,10 @@ on:
 #   }
 # }
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   run:
     runs-on: ubuntu-latest
@@ -42,10 +46,10 @@ jobs:
       GH_TOKEN: ${{secrets.WORKFLOW_TOKEN}}
     steps:
       - name: Get Run Info
-        id: get-obj
         env:
           INPUTS_CONTEXT: ${{ toJson(inputs) }}
         run: |
+          set -euo pipefail
           export DATE=$(date +%F)
           export RAPIDS_VERSION=${{ inputs.rapids_version }}
           export UCX_PY_VERSION="$(curl -sL https://version.gpuci.io/rapids/${RAPIDS_VERSION})"
@@ -84,4 +88,21 @@ jobs:
             }'
           )
 
-          echo "obj=${OBJ}" | tee --append ${GITHUB_OUTPUT}
+          echo "${OBJ}" | tee --append "${GITHUB_ENV}"
+      - name: Assign outputs
+        id: get-obj
+        run: echo "obj=${OBJ}" >> "${GITHUB_OUTPUT}"
+      - name: Print Summary
+        env:
+          RAPIDS_VERSION: ${{ inputs.rapids_version }}
+          RUN_TESTS: ${{ inputs.run_tests }}
+        run: |
+          set -euo pipefail
+          echo "## \`${RAPIDS_VERSION}\` Nightly Run" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Run tests**: \`${RUN_TESTS}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Run parameters**:" >> "$GITHUB_STEP_SUMMARY"
+
+          echo "\`\`\`json" >> "$GITHUB_STEP_SUMMARY"
+          echo "$(jq -n 'env.OBJ|fromjson')" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/get-run-info.yaml
+++ b/.github/workflows/get-run-info.yaml
@@ -46,6 +46,7 @@ jobs:
       GH_TOKEN: ${{secrets.WORKFLOW_TOKEN}}
     steps:
       - name: Get Run Info
+        id: get-obj
         env:
           INPUTS_CONTEXT: ${{ toJson(inputs) }}
         run: |
@@ -89,9 +90,7 @@ jobs:
           )
 
           echo "OBJ=${OBJ}" | tee --append "${GITHUB_ENV}"
-      - name: Assign outputs
-        id: get-obj
-        run: echo "obj=${OBJ}" >> "${GITHUB_OUTPUT}"
+          echo "obj=${OBJ}" >> "${GITHUB_OUTPUT}"
       - name: Print Summary
         env:
           RAPIDS_VERSION: ${{ inputs.rapids_version }}

--- a/.github/workflows/get-run-info.yaml
+++ b/.github/workflows/get-run-info.yaml
@@ -88,7 +88,7 @@ jobs:
             }'
           )
 
-          echo "${OBJ}" | tee --append "${GITHUB_ENV}"
+          echo "OBJ=${OBJ}" | tee --append "${GITHUB_ENV}"
       - name: Assign outputs
         id: get-obj
         run: echo "obj=${OBJ}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -12,11 +12,8 @@ on:
         required: true
         type: boolean
 
-# the static `nightly` string is needed to differentiate
-# this concurrency config from similar configs that exist
-# in called workflows, which causes problems
 concurrency:
-  group: nightly-${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.rapids_version }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
This PR updates our nightly pipeline to make the following changes:

- Fixes the concurrency settings so that multiple RAPIDS versions can build each night without cancelling each other (like what happened between these runs last night [1](https://github.com/rapidsai/actions/actions/runs/5196186601), [2](https://github.com/rapidsai/actions/actions/runs/5196186864))
  - Also, the `nightly-` prefix and associated comment aren't needed anymore since we're not using `workflow_call` events downstream anymore
- Prints the RAPIDS version & nightly run parameters to a job summary card for the `get-run-info.yaml` workflow
  - This will make it easier to discern what version of RAPIDS was used (and which commits) for the particular workflow run that you're viewing