### PR TITLE
Fix concurrency for nightly pipeline

### DIFF
--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -13,7 +13,7 @@ on:
         type: boolean
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.rapids_version }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.inputs.rapids_version }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
This PR fixes the concurrency settings for our nightly pipeline so that multiple pipelines can run in parallel.

Despite [these](https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability) GitHub docs saying that the `inputs` context is available in the `concurrency` stanza, it doesn't seem to be working.

I found the solution below from the community which seemed to resolve the issue in my local testing:

- https://github.com/orgs/community/discussions/35341#discussioncomment-4901766