### PR TITLE
Update nightly matrix

### DIFF
--- a/.github/workflows/nightly-pipeline-trigger.yaml
+++ b/.github/workflows/nightly-pipeline-trigger.yaml
@@ -11,10 +11,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - rapids_version: "23.06"
-            run_tests: true
           - rapids_version: "23.08"
-            run_tests: false
+            run_tests: true
     steps:
       - uses: actions/checkout@v3
       - name: Trigger Pipeline


### PR DESCRIPTION
Release `23.06` is complete.

Therefore it can be removed from our nightly matrix runs.

I've also enabled tests now for the `23.08` branch.