### PR TITLE
Add kvikio to pipeline as cudf dependency.

### DIFF
--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -34,6 +34,7 @@ jobs:
         rapidsai/cuspatial
         rapidsai/cuxfilter
         rapidsai/dask-cuda
+        rapidsai/kvikio
         rapidsai/raft
         rapidsai/rmm
         rapidsai/ucxx
@@ -73,8 +74,42 @@ jobs:
           propagate_failure: true
           trigger_workflow: true
           wait_workflow: true
+  kvikio-build:
+    needs: get-run-info
+    runs-on: ubuntu-latest
+    steps:
+      - uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: rapidsai
+          repo: kvikio
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+          github_user: GPUtester
+          workflow_file_name: build.yaml
+          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+          wait_interval: 120
+          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.kvikio) }}
+          propagate_failure: true
+          trigger_workflow: true
+          wait_workflow: true
+  kvikio-tests:
+    needs: [get-run-info, kvikio-build]
+    if: ${{ needs.kvikio-build.result == 'success' && inputs.run_tests }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: rapidsai
+          repo: kvikio
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+          github_user: GPUtester
+          workflow_file_name: test.yaml
+          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+          wait_interval: 120
+          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.kvikio) }}
+          propagate_failure: true
+          trigger_workflow: true
   cudf-build:
-    needs: [get-run-info, rmm-build, dask-cuda-build]
+    needs: [get-run-info, rmm-build, dask-cuda-build, kvikio-build]
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
     steps:


### PR DESCRIPTION
This PR addresses failures seen in https://github.com/rapidsai/cudf/actions/runs/5615609583 where cudf failed to build, due to a missing 23.10 kvikio dependency on the first build of 23.10. This resolves #23.