### PR TITLE
Add `run-name` to nightly pipeline

### DIFF
--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -1,4 +1,5 @@
 name: Nightly RAPIDS Pipeline
+run-name: "Nightly RAPIDS v${{ inputs.rapids_version }} Pipeline"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
This will add the version more prominently in the WebUI to help distinguish during burndown which version the pipeline is for.

Docs: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#run-name

I also debated adding a `name` to each `job` with the version. But that might be overkill.
