### PR TITLE
Fix: cuml requires cumlprims_mg and other missing dependencies

### DIFF
--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -254,7 +254,7 @@ jobs:
           trigger_workflow: true
           wait_workflow: true
   cuml-build:
-    needs: [get-run-info, cudf-build, raft-build]
+    needs: [get-run-info, cudf-build, raft-build, cumlprims_mg-build]
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
     steps:

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -613,7 +613,7 @@ jobs:
           trigger_workflow: true
           wait_workflow: true
   ucxx-tests:
-    needs: [get-run-info, ucxx-build]
+    needs: [get-run-info, ucxx-build, cudf-build]
     if: ${{ needs.ucxx-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -290,7 +290,7 @@ jobs:
           trigger_workflow: true
           wait_workflow: true
   cugraph-build:
-    needs: [get-run-info, cudf-build, raft-build, dask-cuda-build, cugraph-ops-build]
+    needs: [get-run-info, rmm-build, cudf-build, raft-build, dask-cuda-build, cugraph-ops-build]
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
     steps:

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -42,7 +42,7 @@ jobs:
         rapidsai/ucxx
         rapidsai/ucx-py
   rmm-build:
-    needs: get-run-info
+    needs: [get-run-info]
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -77,7 +77,7 @@ jobs:
           trigger_workflow: true
           wait_workflow: true
   rapids-cmake-build:
-    needs: get-run-info
+    needs: [get-run-info]
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -112,7 +112,7 @@ jobs:
           trigger_workflow: true
           wait_workflow: true
   kvikio-build:
-    needs: get-run-info
+    needs: [get-run-info]
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -470,7 +470,7 @@ jobs:
           trigger_workflow: true
           wait_workflow: true
   ucx-py-build:
-    needs: get-run-info
+    needs: [get-run-info]
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
     steps:

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -290,7 +290,7 @@ jobs:
           trigger_workflow: true
           wait_workflow: true
   cugraph-build:
-    needs: [get-run-info, cudf-build, raft-build, dask-cuda-build]
+    needs: [get-run-info, cudf-build, raft-build, dask-cuda-build, cugraph-ops-build]
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
     steps:

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -362,7 +362,7 @@ jobs:
           trigger_workflow: true
           wait_workflow: true
   cuspatial-build:
-    needs: [get-run-info, cudf-build]
+    needs: [get-run-info, rmm-build, cudf-build]
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
     steps:


### PR DESCRIPTION
The `cuml` package build requires `cumlprims_mg` to run first. We currently aren't requiring this as a dependency, meaning that last night's 23.10 nightlies failed with the error `nothing provides requested libcumlprims 23.10.*`.

Failed jobs: https://github.com/rapidsai/cuml/actions/runs/5653532547/attempts/1

Direct link to failure: https://github.com/rapidsai/cuml/actions/runs/5653532547/job/15314872590#step:7:512


I also took this opportunity to review the full dependency list in our nightlies. I fixed several other missing dependencies, too:
- cugraph needs cugraph-ops
- cuspatial needs rmm (which is implied by needing cudf -- do we want to encapsulate the full dependency graph or just the [transitive reduction](https://en.wikipedia.org/wiki/Transitive_reduction) of that graph? Currently the graph is a bit inconsistent about this.)
- ucxx tests require cudf builds
- cugraph requires rmm (similar to above, implied by requiring cudf)