### PR TITLE
Add ops as codeowners.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+#build/ops code owners
+* @rapidsai/ops-codeowners


### PR DESCRIPTION
This PR enables CODEOWNERS for the `actions` nightly workflows repo.