### PR TITLE
Add rapidsai/docker to nightly pipeline

### DIFF
--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -35,6 +35,7 @@ jobs:
         rapidsai/cuspatial
         rapidsai/cuxfilter
         rapidsai/dask-cuda
+        rapidsai/docker
         rapidsai/kvikio
         rapidsai/rapids-cmake
         rapidsai/raft
@@ -631,6 +632,41 @@ jobs:
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).ucx-py-branch }}
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.ucxx) }}
+          propagate_failure: true
+          trigger_workflow: true
+          wait_workflow: true
+  docker-build-and-test:
+    needs:
+      - get-run-info
+      - cucim-build
+      - cudf-build
+      - cugraph-build
+      - cugraph-ops-build
+      - cuml-build
+      - cumlprims_mg-build
+      - cusignal-build
+      - cuspatial-build
+      - cuxfilter-build
+      - dask-cuda-build
+      - kvikio-build
+      - raft-build
+      - rapids-cmake-build
+      - rmm-build
+      - ucx-py-build
+      - ucxx-build
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: rapidsai
+          repo: docker
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+          github_user: GPUtester
+          workflow_file_name: publish.yaml
+          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+          wait_interval: 120
+          client_payload: '{"run_tests": ${{ inputs.run_tests }} }'
           propagate_failure: true
           trigger_workflow: true
           wait_workflow: true


### PR DESCRIPTION
Adds `rapidsai/docker` to the nightly pipeline.

This implementation differs from other repositories because the `docker` repo workflows combine build & test in a single workflow due to using temporary images during testing. I think a future enhancement should be to refactor the `docker` workflows to allow for split builds and tests which would be more flexible.

Depends on https://github.com/rapidsai/docker/pull/565
