### PR TITLE
Remove cusignal.

### DIFF
--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -31,7 +31,6 @@ jobs:
         rapidsai/cuml
         rapidsai/cumlprims_mg
         rapidsai/cuopt
-        rapidsai/cusignal
         rapidsai/cuspatial
         rapidsai/cuxfilter
         rapidsai/dask-cuda
@@ -329,42 +328,6 @@ jobs:
           propagate_failure: true
           trigger_workflow: true
           wait_workflow: true
-  cusignal-build:
-    needs: [get-run-info]
-    if: ${{ !cancelled() }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: convictional/trigger-workflow-and-wait@v1.6.5
-        with:
-          owner: rapidsai
-          repo: cusignal
-          github_token: ${{ secrets.WORKFLOW_TOKEN }}
-          github_user: GPUtester
-          workflow_file_name: build.yaml
-          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-          wait_interval: 120
-          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cusignal) }}
-          propagate_failure: true
-          trigger_workflow: true
-          wait_workflow: true
-  cusignal-tests:
-    needs: [get-run-info, cusignal-build]
-    if: ${{ needs.cusignal-build.result == 'success' && !cancelled() && inputs.run_tests }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: convictional/trigger-workflow-and-wait@v1.6.5
-        with:
-          owner: rapidsai
-          repo: cusignal
-          github_token: ${{ secrets.WORKFLOW_TOKEN }}
-          github_user: GPUtester
-          workflow_file_name: test.yaml
-          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-          wait_interval: 120
-          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cusignal) }}
-          propagate_failure: true
-          trigger_workflow: true
-          wait_workflow: true
   cuspatial-build:
     needs: [get-run-info, rmm-build, cudf-build]
     if: ${{ !cancelled() }}
@@ -644,7 +607,6 @@ jobs:
       - cugraph-ops-build
       - cuml-build
       - cumlprims_mg-build
-      - cusignal-build
       - cuspatial-build
       - cuxfilter-build
       - dask-cuda-build


### PR DESCRIPTION
This PR removes cusignal from the nightly CI workflow. The repo is deprecated and its last release is 23.08. https://docs.rapids.ai/notices/rsn0032/