### PR TITLE
Remove 23.08 nightlies

### DIFF
--- a/.github/workflows/nightly-pipeline-trigger.yaml
+++ b/.github/workflows/nightly-pipeline-trigger.yaml
@@ -11,10 +11,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - rapids_version: "23.08"
-            run_tests: true
           - rapids_version: "23.10"
-            run_tests: false
+            run_tests: true
     steps:
       - uses: actions/checkout@v3
       - name: Trigger Pipeline


### PR DESCRIPTION
The `23.08` release is complete, so we can disable nightlies.

Additionally, we can enable testing for `23.10`.
