### PR TITLE
Add wholegraph to nighlty pipeline

### DIFF
--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -41,6 +41,7 @@ jobs:
         rapidsai/rmm
         rapidsai/ucxx
         rapidsai/ucx-py
+        rapidsai/wholegraph
   rmm-build:
     needs: [get-run-info]
     if: ${{ !cancelled() }}
@@ -598,6 +599,42 @@ jobs:
           propagate_failure: true
           trigger_workflow: true
           wait_workflow: true
+  wholegraph-build:
+    needs: [get-run-info, rmm-build, raft-build]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: rapidsai
+          repo: wholegraph
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+          github_user: GPUtester
+          workflow_file_name: build.yaml
+          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+          wait_interval: 120
+          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.wholegraph) }}
+          propagate_failure: true
+          trigger_workflow: true
+          wait_workflow: true
+  wholegraph-tests:
+    needs: [get-run-info, wholegraph-build]
+    if: ${{ needs.wholegraph-build.result == 'success' && !cancelled() && inputs.run_tests }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: rapidsai
+          repo: wholegraph
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+          github_user: GPUtester
+          workflow_file_name: test.yaml
+          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+          wait_interval: 120
+          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.wholegraph) }}
+          propagate_failure: true
+          trigger_workflow: true
+          wait_workflow: true
   docker-build-and-test:
     needs:
       - get-run-info
@@ -616,6 +653,7 @@ jobs:
       - rmm-build
       - ucx-py-build
       - ucxx-build
+      - wholegraph-build
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Just adds wholegraph to the nightly pipeline. It should only depend on `rmm` & `raft` based on the recipes.
