### PR TITLE
add cugraph-gnn, remove wholegraph

### DIFF
--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -348,7 +348,7 @@ jobs:
           propagate_failure: true
           trigger_workflow: true
           wait_workflow: true
-  cugraph-tests:
+  cugraph-gnn-tests:
     needs: [get-run-info, cugraph-gnn-build]
     if: ${{ needs.cugraph-gnn-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
Development of `wholegraph`, `cugraph-dgl`, and `cugraph-pyg` is moving to https://github.com/rapidsai/cugraph-gnn.

This updates the nightly pipeline to reflect that:

* removes triggers for https://github.com/rapidsai/wholegraph
* adds triggers for https://github.com/rapidsai/cugraph-gnn
* also fixes a small dependency mistake from #63

## Notes for Reviewers

This should not be merged until the following are done:

* [x] stop publishing from `wholegraph` (https://github.com/rapidsai/wholegraph/pull/233)
* [x] stop publishing from `cugraph` (https://github.com/rapidsai/cugraph/pull/4752)
* [x] start publishing from `cugraph-gnn` (https://github.com/rapidsai/cugraph-gnn/pull/66)