### PR TITLE
Fix rapidsmpf-build job name

### DIFF
--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -749,7 +749,7 @@ jobs:
       - kvikio-build
       - nx-cugraph-build
       - raft-build
-      - rapidsmpf
+      - rapidsmpf-build
       - rmm-build
       - ucx-py-build
       - ucxx-build


### PR DESCRIPTION
Fix wrong job name added in #82 .