### PR TITLE
Switch to 25.10 testing

### DIFF
--- a/.github/workflows/nightly-pipeline-trigger.yaml
+++ b/.github/workflows/nightly-pipeline-trigger.yaml
@@ -11,10 +11,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - rapids_version: "25.08"
-            run_tests: true
           - rapids_version: "25.10"
-            run_tests: false
+            run_tests: true
     steps:
       - uses: actions/checkout@v3
       - name: Trigger Pipeline


### PR DESCRIPTION
The 25.08 release is complete, so remove its trigger and update 25.10's trigger to run tests.