### PR TITLE
Drop ucx-py from nightly builds/tests

### DIFF
--- a/.github/workflows/get-run-info.yaml
+++ b/.github/workflows/get-run-info.yaml
@@ -12,24 +12,24 @@ on:
 
 # The output object looks like this:
 # {
-#   "branch": "branch-22.10",
-#   "ucx-py-branch": "branch-0.28",
+#   "branch": "branch-25.10",
+#   "ucxx-branch": "branch-0.46",
 #   "payloads": {
 #     "rmm": {
-#        "branch": "branch-22.10",
-#        "date": "2022-09-01",
-#        "sha": "8a3a552e07fa8254c54804addcab103aea89f985"
-#      },
+#       "branch": "branch-25.10",
+#       "date": "2025-09-16",
+#       "sha": "de85ed361daa9868df15f62aff257e0cef291843"
+#     },
 #     "cudf": {
-#        "branch": "branch-22.10",
-#        "date": "2022-09-01",
-#        "sha": "dfd3d89392fa4710752e3067b16fa9a2edb28174"
-#      },
-#     "ucx-py": {
-#        "branch": "branch-0.28",
-#        "date": "2022-09-01",
-#        "sha": "daf117ca01c37508f102666b3b4999b955a16a12"
-#      }
+#       "branch": "branch-25.10",
+#       "date": "2025-09-16",
+#       "sha": "fec23dd8cc35429a4e164ea95f13f2702a7daa91"
+#     },
+#     "ucxx": {
+#       "branch": "branch-0.46",
+#       "date": "2025-09-16",
+#       "sha": "71a3af8bc473a0b87667d9a58af4476e9653ce20"
+#     }
 #   }
 # }
 
@@ -53,9 +53,9 @@ jobs:
           set -euo pipefail
           export DATE=$(date +%F)
           export RAPIDS_VERSION=${{ inputs.rapids_version }}
-          export UCX_PY_VERSION="$(curl -sL https://version.gpuci.io/rapids/${RAPIDS_VERSION})"
+          export UCXX_VERSION="$(curl -sL https://version.gpuci.io/rapids/${RAPIDS_VERSION})"
           export RAPIDS_BRANCH="branch-${RAPIDS_VERSION}"
-          export UCX_PY_BRANCH="branch-${UCX_PY_VERSION}"
+          export UCXX_BRANCH="branch-${UCXX_VERSION}"
 
           export REPOS=$(echo "${{ inputs.repos }}" | jq -Rc 'split(" ")')
 
@@ -64,8 +64,8 @@ jobs:
             export JUST_REPO=${REPO##*/} # removes GH organization
             export BRANCH="${RAPIDS_BRANCH}"
 
-            if [ "${JUST_REPO}" = "ucx-py" ] || [ "${JUST_REPO}" = "ucxx" ]; then
-              export BRANCH="${UCX_PY_BRANCH}"
+            if [ "${JUST_REPO}" = "ucxx" ]; then
+              export BRANCH="${UCXX_BRANCH}"
             fi
 
             SHA=$(gh api -q '.commit.sha' "repos/${REPO}/branches/${BRANCH}")
@@ -84,7 +84,7 @@ jobs:
           OBJ=$(
             jq -nc '{
               "branch": env.RAPIDS_BRANCH,
-              "ucx-py-branch": env.UCX_PY_BRANCH,
+              "ucxx-branch": env.UCXX_BRANCH,
               "payloads": (env.PAYLOADS|fromjson)
             }'
           )

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -50,7 +50,6 @@ jobs:
         rapidsai/raft
         rapidsai/rmm
         rapidsai/ucxx
-        rapidsai/ucx-py
   rmm-build:
     needs: [get-run-info]
     if: ${{ !cancelled() }}
@@ -195,7 +194,7 @@ jobs:
           trigger_workflow: true
           wait_workflow: true
   raft-tests:
-    needs: [get-run-info, raft-build, ucx-py-build]
+    needs: [get-run-info, raft-build]
     if: ${{ needs.raft-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
@@ -463,42 +462,6 @@ jobs:
           propagate_failure: true
           trigger_workflow: true
           wait_workflow: true
-  ucx-py-build:
-    needs: [get-run-info]
-    if: ${{ !cancelled() }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
-        with:
-          owner: rapidsai
-          repo: ucx-py
-          github_token: ${{ secrets.WORKFLOW_TOKEN }}
-          github_user: GPUtester
-          workflow_file_name: build.yaml
-          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).ucx-py-branch }}
-          wait_interval: 120
-          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.ucx-py) }}
-          propagate_failure: true
-          trigger_workflow: true
-          wait_workflow: true
-  ucx-py-tests:
-    needs: [get-run-info, ucx-py-build, cudf-build]
-    if: ${{ needs.ucx-py-build.result == 'success' && !cancelled() && inputs.run_tests }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
-        with:
-          owner: rapidsai
-          repo: ucx-py
-          github_token: ${{ secrets.WORKFLOW_TOKEN }}
-          github_user: GPUtester
-          workflow_file_name: test.yaml
-          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).ucx-py-branch }}
-          wait_interval: 120
-          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.ucx-py) }}
-          propagate_failure: true
-          trigger_workflow: true
-          wait_workflow: true
   cucim-build:
     needs: [get-run-info]
     if: ${{ !cancelled() }}
@@ -583,7 +546,7 @@ jobs:
           github_token: ${{ secrets.WORKFLOW_TOKEN }}
           github_user: GPUtester
           workflow_file_name: build.yaml
-          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).ucx-py-branch }}
+          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).ucxx-branch }}
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.ucxx) }}
           propagate_failure: true
@@ -601,7 +564,7 @@ jobs:
           github_token: ${{ secrets.WORKFLOW_TOKEN }}
           github_user: GPUtester
           workflow_file_name: test.yaml
-          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).ucx-py-branch }}
+          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).ucxx-branch }}
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.ucxx) }}
           propagate_failure: true
@@ -658,7 +621,6 @@ jobs:
       - nx-cugraph-build
       - raft-build
       - rmm-build
-      - ucx-py-build
       - ucxx-build
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
@@ -712,7 +674,6 @@ jobs:
       - raft-build
       - rapidsmpf-build
       - rmm-build
-      - ucx-py-build
       - ucxx-build
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
RAPIDS 25.10 will not include `ucx-py` ... that project is being archived (https://github.com/rapidsai/build-planning/issues/198).

This removes it from the list of nightly builds / tests.