### PR TITLE
Update trigger-workflow-and-wait to v1.6.5-rapids1

### DIFF
--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -55,7 +55,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@v1.6.5-rapids1
         with:
           owner: rapidsai
           repo: rmm
@@ -73,7 +73,7 @@ jobs:
     if: ${{ needs.rmm-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@v1.6.5-rapids1
         with:
           owner: rapidsai
           repo: rmm
@@ -91,7 +91,7 @@ jobs:
     if: ${{ !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@v1.6.5-rapids1
         with:
           owner: rapidsai
           repo: rapids-cmake
@@ -109,7 +109,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@v1.6.5-rapids1
         with:
           owner: rapidsai
           repo: kvikio
@@ -127,7 +127,7 @@ jobs:
     if: ${{ needs.kvikio-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@v1.6.5-rapids1
         with:
           owner: rapidsai
           repo: kvikio
@@ -144,7 +144,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@v1.6.5-rapids1
         with:
           owner: rapidsai
           repo: cudf
@@ -162,7 +162,7 @@ jobs:
     if: ${{ needs.cudf-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@v1.6.5-rapids1
         with:
           owner: rapidsai
           repo: cudf
@@ -180,7 +180,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@v1.6.5-rapids1
         with:
           owner: rapidsai
           repo: raft
@@ -198,7 +198,7 @@ jobs:
     if: ${{ needs.raft-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@v1.6.5-rapids1
         with:
           owner: rapidsai
           repo: raft
@@ -216,7 +216,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@v1.6.5-rapids1
         with:
           owner: rapidsai
           repo: cuvs
@@ -234,7 +234,7 @@ jobs:
     if: ${{ needs.cuvs-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@v1.6.5-rapids1
         with:
           owner: rapidsai
           repo: cuvs
@@ -251,7 +251,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@v1.6.5-rapids1
         with:
           owner: rapidsai
           repo: cuml
@@ -269,7 +269,7 @@ jobs:
     if: ${{ needs.cuml-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@v1.6.5-rapids1
         with:
           owner: rapidsai
           repo: cuml
@@ -287,7 +287,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@v1.6.5-rapids1
         with:
           owner: rapidsai
           repo: cugraph
@@ -305,7 +305,7 @@ jobs:
     if: ${{ needs.cugraph-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@v1.6.5-rapids1
         with:
           owner: rapidsai
           repo: cugraph
@@ -323,7 +323,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@v1.6.5-rapids1
         with:
           owner: rapidsai
           repo: cugraph-gnn
@@ -341,7 +341,7 @@ jobs:
     if: ${{ needs.cugraph-gnn-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@v1.6.5-rapids1
         with:
           owner: rapidsai
           repo: cugraph-gnn
@@ -359,7 +359,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@v1.6.5-rapids1
         with:
           owner: rapidsai
           repo: nx-cugraph
@@ -377,7 +377,7 @@ jobs:
     if: ${{ needs.nx-cugraph-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@v1.6.5-rapids1
         with:
           owner: rapidsai
           repo: nx-cugraph
@@ -395,7 +395,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@v1.6.5-rapids1
         with:
           owner: rapidsai
           repo: cuxfilter
@@ -413,7 +413,7 @@ jobs:
     if: ${{ needs.cuxfilter-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@v1.6.5-rapids1
         with:
           owner: rapidsai
           repo: cuxfilter
@@ -431,7 +431,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@v1.6.5-rapids1
         with:
           owner: rapidsai
           repo: dask-cuda
@@ -449,7 +449,7 @@ jobs:
     if: ${{ needs.dask-cuda-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@v1.6.5-rapids1
         with:
           owner: rapidsai
           repo: dask-cuda
@@ -467,7 +467,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@v1.6.5-rapids1
         with:
           owner: rapidsai
           repo: cucim
@@ -485,7 +485,7 @@ jobs:
     if: ${{ needs.cucim-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@v1.6.5-rapids1
         with:
           owner: rapidsai
           repo: cucim
@@ -503,7 +503,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@v1.6.5-rapids1
         with:
           owner: rapidsai
           repo: cumlprims_mg
@@ -521,7 +521,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@v1.6.5-rapids1
         with:
           owner: rapidsai
           repo: cugraph-docs
@@ -539,7 +539,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@v1.6.5-rapids1
         with:
           owner: rapidsai
           repo: ucxx
@@ -557,7 +557,7 @@ jobs:
     if: ${{ needs.ucxx-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@v1.6.5-rapids1
         with:
           owner: rapidsai
           repo: ucxx
@@ -575,7 +575,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@v1.6.5-rapids1
         with:
           owner: rapidsai
           repo: rapidsmpf
@@ -593,7 +593,7 @@ jobs:
     if: ${{ needs.rapidsmpf-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@v1.6.5-rapids1
         with:
           owner: rapidsai
           repo: rapidsmpf
@@ -625,7 +625,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@v1.6.5-rapids1
         with:
           owner: rapidsai
           repo: integration
@@ -645,7 +645,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@v1.6.5-rapids1
         with:
           owner: rapidsai
           repo: integration
@@ -678,7 +678,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@v1.6.5-rapids1
         with:
           owner: rapidsai
           repo: docker


### PR DESCRIPTION
Updates to include https://github.com/rapidsai/trigger-workflow-and-wait/pull/3.
