### PR TITLE
fix(ci): resolve all zizmor findings and add zizmor pre-commit checks

### DIFF
--- a/.github/workflows/cleanup_staging.yaml
+++ b/.github/workflows/cleanup_staging.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Run With DockerHub Token
       uses: rapidsai/shared-actions/dockerhub-script@main

--- a/.github/workflows/cleanup_staging.yaml
+++ b/.github/workflows/cleanup_staging.yaml
@@ -5,6 +5,8 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest
@@ -12,6 +14,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Run With DockerHub Token
       uses: rapidsai/shared-actions/dockerhub-script@main

--- a/.github/workflows/get-run-info.yaml
+++ b/.github/workflows/get-run-info.yaml
@@ -41,6 +41,8 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/.github/workflows/get-run-info.yaml
+++ b/.github/workflows/get-run-info.yaml
@@ -13,6 +13,9 @@ on:
       obj:
         description: "A JSON object which includes the relevant information for a particular workflow run."
         value: ${{ jobs.run.outputs.obj }}
+    secrets:
+      WORKFLOW_TOKEN:
+        required: true
 
 # The output object looks like this:
 # {

--- a/.github/workflows/nightly-pipeline-trigger.yaml
+++ b/.github/workflows/nightly-pipeline-trigger.yaml
@@ -14,7 +14,7 @@ jobs:
           - rapids_branch: "main"
             run_tests: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Trigger Pipeline
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/nightly-pipeline-trigger.yaml
+++ b/.github/workflows/nightly-pipeline-trigger.yaml
@@ -5,6 +5,8 @@ on:
   schedule:
     - cron: "0 5 * * *" # 5am UTC / 1am EST
 
+permissions: {}
+
 jobs:
   trigger-pipeline:
     runs-on: ubuntu-latest
@@ -15,6 +17,8 @@ jobs:
             run_tests: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Trigger Pipeline
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -30,7 +30,8 @@ permissions: {}
 jobs:
   get-run-info:
     uses: ./.github/workflows/get-run-info.yaml
-    secrets: inherit
+    secrets:
+      WORKFLOW_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
     with:
       rapids_branch: "${{ inputs.rapids_branch }}"
       repos: >-

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.inputs.rapids_branch }}
   cancel-in-progress: true
 
+
+permissions: {}
+
 # We intentionally allow build jobs to proceed even if their dependencies
 # failed since the upstream failures may be unrelated. This is the reason for
 # the many `if: ${{ !cancelled() }}` conditionals below. This short-circuits

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -56,7 +56,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: rmm
@@ -74,7 +74,7 @@ jobs:
     if: ${{ needs.rmm-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: rmm
@@ -92,7 +92,7 @@ jobs:
     if: ${{ !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: rapids-cmake
@@ -110,7 +110,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: kvikio
@@ -128,7 +128,7 @@ jobs:
     if: ${{ needs.kvikio-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: kvikio
@@ -145,7 +145,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: cudf
@@ -163,7 +163,7 @@ jobs:
     if: ${{ needs.cudf-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: cudf
@@ -181,7 +181,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: raft
@@ -199,7 +199,7 @@ jobs:
     if: ${{ needs.raft-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: raft
@@ -217,7 +217,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: cuvs
@@ -235,7 +235,7 @@ jobs:
     if: ${{ needs.cuvs-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: cuvs
@@ -252,7 +252,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: cuvs-lucene
@@ -271,7 +271,7 @@ jobs:
     if: ${{ needs.cuvs-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: cuvs-lucene
@@ -289,7 +289,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: nvforest
@@ -307,7 +307,7 @@ jobs:
     if: ${{ needs.nvforest-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: nvforest
@@ -325,7 +325,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: cuml
@@ -343,7 +343,7 @@ jobs:
     if: ${{ needs.cuml-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: cuml
@@ -361,7 +361,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: cugraph
@@ -379,7 +379,7 @@ jobs:
     if: ${{ needs.cugraph-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: cugraph
@@ -397,7 +397,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: cugraph-gnn
@@ -415,7 +415,7 @@ jobs:
     if: ${{ needs.cugraph-gnn-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: cugraph-gnn
@@ -433,7 +433,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: nx-cugraph
@@ -451,7 +451,7 @@ jobs:
     if: ${{ needs.nx-cugraph-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: nx-cugraph
@@ -469,7 +469,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: cuxfilter
@@ -487,7 +487,7 @@ jobs:
     if: ${{ needs.cuxfilter-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: cuxfilter
@@ -505,7 +505,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: dask-cuda
@@ -523,7 +523,7 @@ jobs:
     if: ${{ needs.dask-cuda-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: dask-cuda
@@ -541,7 +541,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: cucim
@@ -559,7 +559,7 @@ jobs:
     if: ${{ needs.cucim-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: cucim
@@ -577,7 +577,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: cugraph-docs
@@ -595,7 +595,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: ucxx
@@ -613,7 +613,7 @@ jobs:
     if: ${{ needs.ucxx-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: ucxx
@@ -631,7 +631,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: rapidsmpf
@@ -649,7 +649,7 @@ jobs:
     if: ${{ needs.rapidsmpf-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: rapidsmpf
@@ -679,7 +679,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: integration
@@ -699,7 +699,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: integration
@@ -722,7 +722,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
+      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
         with:
           owner: rapidsai
           repo: docker

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,11 +7,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   checks:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Run pre-commit
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,6 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run pre-commit
-        uses: pre-commit/action@v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,9 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # We require SHA-pinning for all workflows and actions _except_ for those from
+        # rapidsai/shared-workflows and rapidsai/shared-actions
+        "rapidsai/shared-workflows/*": any
+        "rapidsai/shared-actions/*": any
+        "*": hash-pin

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,7 @@ repos:
     rev: v0.11.0.1
     hooks:
       - id: shellcheck
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.24.1
+    hooks:
+      - id: zizmor


### PR DESCRIPTION

Similar to upstream changes in `shared-workflows`, this PR cleans up and annotates all of the workflows and adds the `zizmor` linter to make sure changes are checked.

Part of https://github.com/rapidsai/build-planning/issues/275