### PR TITLE
fix(permissions): relax permissions so we can trigger nightly builds

### DIFF
--- a/.github/workflows/nightly-pipeline-trigger.yaml
+++ b/.github/workflows/nightly-pipeline-trigger.yaml
@@ -5,8 +5,6 @@ on:
   schedule:
     - cron: "0 5 * * *" # 5am UTC / 1am EST
 
-permissions: {}
-
 jobs:
   trigger-pipeline:
     runs-on: ubuntu-latest
@@ -15,6 +13,9 @@ jobs:
         include:
           - rapids_branch: "main"
             run_tests: true
+    permissions:
+      contents: read
+      actions: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -18,7 +18,11 @@ concurrency:
   cancel-in-progress: true
 
 
-permissions: {}
+permissions:
+  contents: read
+  actions: write  # zizmor: ignore[excessive-permissions]
+  packages: read
+  pull-requests: read
 
 # We intentionally allow build jobs to proceed even if their dependencies
 # failed since the upstream failures may be unrelated. This is the reason for


### PR DESCRIPTION
Followup to #113 which inadvertantly broke nightly builds by restricting permissions too much.  I think these permissions are sufficient to trigger a run.
