### PR TITLE
Add nvforest to cuml nightly dependencies

### DIFF
--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -329,7 +329,7 @@ jobs:
           trigger_workflow: true
           wait_workflow: true
   cuml-build:
-    needs: [get-run-info, cudf-build, raft-build, cuvs-build]
+    needs: [get-run-info, cudf-build, raft-build, cuvs-build, nvforest-build]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Updates the nightly pipeline so `cuml-build` waits for `nvforest-build` now that `cuml` depends on `nvforest`.

Closes https://github.com/rapidsai/nvforest/issues/59
