### PR TITLE
use 'trigger-workflow-and-wait' from 'rapidsai/shared-actions'

### DIFF
--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -64,7 +64,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: rmm
@@ -82,7 +82,7 @@ jobs:
     if: ${{ needs.rmm-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: rmm
@@ -100,7 +100,7 @@ jobs:
     if: ${{ !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: rapids-cmake
@@ -118,7 +118,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: kvikio
@@ -136,7 +136,7 @@ jobs:
     if: ${{ needs.kvikio-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: kvikio
@@ -153,7 +153,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: cudf
@@ -171,7 +171,7 @@ jobs:
     if: ${{ needs.cudf-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: cudf
@@ -189,7 +189,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: raft
@@ -207,7 +207,7 @@ jobs:
     if: ${{ needs.raft-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: raft
@@ -225,7 +225,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: cuvs
@@ -243,7 +243,7 @@ jobs:
     if: ${{ needs.cuvs-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: cuvs
@@ -260,7 +260,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: cuvs-lucene
@@ -279,7 +279,7 @@ jobs:
     if: ${{ needs.cuvs-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: cuvs-lucene
@@ -297,7 +297,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: nvforest
@@ -315,7 +315,7 @@ jobs:
     if: ${{ needs.nvforest-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: nvforest
@@ -333,7 +333,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: cuml
@@ -351,7 +351,7 @@ jobs:
     if: ${{ needs.cuml-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: cuml
@@ -369,7 +369,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: cugraph
@@ -387,7 +387,7 @@ jobs:
     if: ${{ needs.cugraph-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: cugraph
@@ -405,7 +405,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: cugraph-gnn
@@ -423,7 +423,7 @@ jobs:
     if: ${{ needs.cugraph-gnn-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: cugraph-gnn
@@ -441,7 +441,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: nx-cugraph
@@ -459,7 +459,7 @@ jobs:
     if: ${{ needs.nx-cugraph-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: nx-cugraph
@@ -477,7 +477,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: cuxfilter
@@ -495,7 +495,7 @@ jobs:
     if: ${{ needs.cuxfilter-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: cuxfilter
@@ -513,7 +513,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: dask-cuda
@@ -531,7 +531,7 @@ jobs:
     if: ${{ needs.dask-cuda-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: dask-cuda
@@ -549,7 +549,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: cucim
@@ -567,7 +567,7 @@ jobs:
     if: ${{ needs.cucim-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: cucim
@@ -585,7 +585,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: cugraph-docs
@@ -603,7 +603,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: ucxx
@@ -621,7 +621,7 @@ jobs:
     if: ${{ needs.ucxx-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: ucxx
@@ -639,7 +639,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: rapidsmpf
@@ -657,7 +657,7 @@ jobs:
     if: ${{ needs.rapidsmpf-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: rapidsmpf
@@ -687,7 +687,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: integration
@@ -707,7 +707,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: integration
@@ -730,7 +730,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: docker

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -64,7 +64,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: rmm
@@ -82,7 +82,7 @@ jobs:
     if: ${{ needs.rmm-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: rmm
@@ -100,7 +100,7 @@ jobs:
     if: ${{ !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: rapids-cmake
@@ -118,7 +118,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: kvikio
@@ -136,7 +136,7 @@ jobs:
     if: ${{ needs.kvikio-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: kvikio
@@ -153,7 +153,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: cudf
@@ -171,7 +171,7 @@ jobs:
     if: ${{ needs.cudf-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: cudf
@@ -189,7 +189,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: raft
@@ -207,7 +207,7 @@ jobs:
     if: ${{ needs.raft-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: raft
@@ -225,7 +225,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: cuvs
@@ -243,7 +243,7 @@ jobs:
     if: ${{ needs.cuvs-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: cuvs
@@ -260,7 +260,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: cuvs-lucene
@@ -279,7 +279,7 @@ jobs:
     if: ${{ needs.cuvs-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: cuvs-lucene
@@ -297,7 +297,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: nvforest
@@ -315,7 +315,7 @@ jobs:
     if: ${{ needs.nvforest-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: nvforest
@@ -333,7 +333,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: cuml
@@ -351,7 +351,7 @@ jobs:
     if: ${{ needs.cuml-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: cuml
@@ -369,7 +369,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: cugraph
@@ -387,7 +387,7 @@ jobs:
     if: ${{ needs.cugraph-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: cugraph
@@ -405,7 +405,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: cugraph-gnn
@@ -423,7 +423,7 @@ jobs:
     if: ${{ needs.cugraph-gnn-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: cugraph-gnn
@@ -441,7 +441,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: nx-cugraph
@@ -459,7 +459,7 @@ jobs:
     if: ${{ needs.nx-cugraph-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: nx-cugraph
@@ -477,7 +477,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: cuxfilter
@@ -495,7 +495,7 @@ jobs:
     if: ${{ needs.cuxfilter-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: cuxfilter
@@ -513,7 +513,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: dask-cuda
@@ -531,7 +531,7 @@ jobs:
     if: ${{ needs.dask-cuda-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: dask-cuda
@@ -549,7 +549,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: cucim
@@ -567,7 +567,7 @@ jobs:
     if: ${{ needs.cucim-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: cucim
@@ -585,7 +585,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: cugraph-docs
@@ -603,7 +603,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: ucxx
@@ -621,7 +621,7 @@ jobs:
     if: ${{ needs.ucxx-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: ucxx
@@ -639,7 +639,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: rapidsmpf
@@ -657,7 +657,7 @@ jobs:
     if: ${{ needs.rapidsmpf-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: rapidsmpf
@@ -687,7 +687,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: integration
@@ -707,7 +707,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: integration
@@ -730,7 +730,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@vendor-trigger-workflow-and-wait
         with:
           owner: rapidsai
           repo: docker

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -64,7 +64,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: rmm
@@ -82,7 +82,7 @@ jobs:
     if: ${{ needs.rmm-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: rmm
@@ -100,7 +100,7 @@ jobs:
     if: ${{ !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: rapids-cmake
@@ -118,7 +118,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: kvikio
@@ -136,7 +136,7 @@ jobs:
     if: ${{ needs.kvikio-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: kvikio
@@ -153,7 +153,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: cudf
@@ -171,7 +171,7 @@ jobs:
     if: ${{ needs.cudf-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: cudf
@@ -189,7 +189,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: raft
@@ -207,7 +207,7 @@ jobs:
     if: ${{ needs.raft-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: raft
@@ -225,7 +225,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: cuvs
@@ -243,7 +243,7 @@ jobs:
     if: ${{ needs.cuvs-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: cuvs
@@ -260,7 +260,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: cuvs-lucene
@@ -279,7 +279,7 @@ jobs:
     if: ${{ needs.cuvs-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: cuvs-lucene
@@ -297,7 +297,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: nvforest
@@ -315,7 +315,7 @@ jobs:
     if: ${{ needs.nvforest-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: nvforest
@@ -333,7 +333,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: cuml
@@ -351,7 +351,7 @@ jobs:
     if: ${{ needs.cuml-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: cuml
@@ -369,7 +369,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: cugraph
@@ -387,7 +387,7 @@ jobs:
     if: ${{ needs.cugraph-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: cugraph
@@ -405,7 +405,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: cugraph-gnn
@@ -423,7 +423,7 @@ jobs:
     if: ${{ needs.cugraph-gnn-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: cugraph-gnn
@@ -441,7 +441,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: nx-cugraph
@@ -459,7 +459,7 @@ jobs:
     if: ${{ needs.nx-cugraph-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: nx-cugraph
@@ -477,7 +477,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: cuxfilter
@@ -495,7 +495,7 @@ jobs:
     if: ${{ needs.cuxfilter-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: cuxfilter
@@ -513,7 +513,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: dask-cuda
@@ -531,7 +531,7 @@ jobs:
     if: ${{ needs.dask-cuda-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: dask-cuda
@@ -549,7 +549,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: cucim
@@ -567,7 +567,7 @@ jobs:
     if: ${{ needs.cucim-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: cucim
@@ -585,7 +585,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: cugraph-docs
@@ -603,7 +603,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: ucxx
@@ -621,7 +621,7 @@ jobs:
     if: ${{ needs.ucxx-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: ucxx
@@ -639,7 +639,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: rapidsmpf
@@ -657,7 +657,7 @@ jobs:
     if: ${{ needs.rapidsmpf-build.result == 'success' && !cancelled() && inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: rapidsmpf
@@ -687,7 +687,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: integration
@@ -707,7 +707,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: integration
@@ -730,7 +730,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rapidsai/trigger-workflow-and-wait@1cd9c92f066afd29d5a9169f45dbf8d42e2a3e99 # v1
+      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
         with:
           owner: rapidsai
           repo: docker


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/workflows/issues/118

Switches from our fork of `trigger-workflow-and-wait` (https://github.com/rapidsai/trigger-workflow-and-wait) to a vendored copy in `rapidsai/shared-actions` (added in https://github.com/rapidsai/shared-actions/pull/114).

See the issue for details on the benefits of that.

## Notes for Reviewers

### How I tested this

On this branch, pinned all these uses to the branch from https://github.com/rapidsai/shared-actions/pull/114 (`vendor-trigger-workflow-and-wait`).

Started a run from this PR's branch (`shared-actions`): https://github.com/rapidsai/workflows/actions/runs/26843781233/job/79157749196

Saw everything trigger successfully and the waiting behavior appear to work: 

<img width="1840" height="628" alt="image" src="https://github.com/user-attachments/assets/d856545e-6103-44d7-992c-30a994aaaf13" />

Saw statuses handled correctly (e.g. successful `dask-cuda-build` triggering a `dask-cuda-tests` job).
