### PR TITLE
remove cuxfilter

### DIFF
--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -47,7 +47,6 @@ jobs:
         rapidsai/cuml
         rapidsai/cuvs
         rapidsai/cuvs-lucene
-        rapidsai/cuxfilter
         rapidsai/dask-cuda
         rapidsai/docker
         rapidsai/integration
@@ -472,42 +471,6 @@ jobs:
           propagate_failure: true
           trigger_workflow: true
           wait_workflow: true
-  cuxfilter-build:
-    needs: [get-run-info, cudf-build, dask-cuda-build]
-    if: ${{ !cancelled() }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
-        with:
-          owner: rapidsai
-          repo: cuxfilter
-          github_token: ${{ secrets.WORKFLOW_TOKEN }}
-          github_user: GPUtester
-          workflow_file_name: build.yaml
-          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-          wait_interval: 120
-          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cuxfilter) }}
-          propagate_failure: true
-          trigger_workflow: true
-          wait_workflow: true
-  cuxfilter-tests:
-    needs: [get-run-info, cuxfilter-build]
-    if: ${{ needs.cuxfilter-build.result == 'success' && !cancelled() && inputs.run_tests }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
-        with:
-          owner: rapidsai
-          repo: cuxfilter
-          github_token: ${{ secrets.WORKFLOW_TOKEN }}
-          github_user: GPUtester
-          workflow_file_name: test.yaml
-          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-          wait_interval: 120
-          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cuxfilter) }}
-          propagate_failure: true
-          trigger_workflow: true
-          wait_workflow: true
   dask-cuda-build:
     needs: [get-run-info]
     if: ${{ !cancelled() }}
@@ -677,9 +640,10 @@ jobs:
       - cudf-build
       - cugraph-build
       - cuml-build
-      - cuxfilter-build
+      - cuvs-build
       - dask-cuda-build
       - kvikio-build
+      - nvforest-build
       - nx-cugraph-build
       - raft-build
       - rmm-build


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/291

Drops `cuxfilter`, which is set to be archived (see linked issue for details).

Also updates the dependencies needed to build https://github.com/rapidsai/integration. A few (notably `cuvs`) were missing.